### PR TITLE
Fixes: epiphany section in basic infos for characters not saved #43

### DIFF
--- a/manuskript/load_save/version_1.py
+++ b/manuskript/load_save/version_1.py
@@ -42,6 +42,7 @@ characterMap = OrderedDict([
     (Character.motivation, "Motivation"),
     (Character.goal, "Goal"),
     (Character.conflict, "Conflict"),
+    (Character.epiphany, "Epiphany"),
     (Character.summarySentence, "Phrase Summary"),
     (Character.summaryPara, "Paragraph Summary"),
     (Character.summaryFull, "Full Summary"),


### PR DESCRIPTION
This one line commit fixes issue #43.  The change permits the epiphany section in basic infos for characters to be load/saved.

Because this commit changes the file manuskript/load_save/version_1.py, I was not sure if a new version needed to be created.

In my testing, a project containing epiphany data was able to load/save both with and without this one line change.