### PR TITLE
Fixes: field "Source of conflict" in World is not active

### DIFF
--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -285,8 +285,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.txtWorldName.setCurrentModelIndex(index)
         self.txtWorldDescription.setCurrentModelIndex(index)
         self.txtWorldPassion.setCurrentModelIndex(index)
-    #     self.txtWorldConflict.setCurrentModelIndex(index)
-    #
+        self.txtWorldConflict.setCurrentModelIndex(index)
+
     # ###############################################################################
     # # LOAD AND SAVE
     # ###############################################################################


### PR DESCRIPTION
This commit enables text entry in the field "Source of conflict" in World section.  The change simply uncomments two lines that were perhaps commented out by accident.

This problem is one of several mentioned in issue #25.