### PR TITLE
Fixes: incorrect reference to 32px icon

### DIFF
--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -23,7 +23,7 @@ def run():
     app.setApplicationVersion(_version)
 
     icon = QIcon()
-    for i in [16, 31, 64, 128, 256, 512]:
+    for i in [16, 32, 64, 128, 256, 512]:
         icon.addFile(appPath("icons/Manuskript/icon-{}px.png".format(i)))
     qApp.setWindowIcon(icon)
 


### PR DESCRIPTION
This is a minor fix to ensure that the correct 32px Manuskript icon is referenced.

@olivierkes, I am working my way through learning QT, Model-View-Controller, and learning and improving Manuskript.  I am a big fan of your choice to use markdown text for storing the novel content.  I also like your choice of having the data stored in directories and plain text files which can be edited with other tools and still work with Manuskript.  Overall you've accomplished a lot with **Manuskript** to be proud of.  :-)