### PR TITLE
Change message from warning to note for failed to load translator string

### DIFF
--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -53,7 +53,7 @@ def run():
         print(app.tr("Loaded translation: {}.").format(translation))
 
     else:
-        print(app.tr("Warning: failed to load translator for locale {}...").format(locale))
+        print(app.tr("Note: No translator found or loaded for locale {}.").format(locale))
 
     QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + [appPath("icons")])
     QIcon.setThemeName("NumixMsk")


### PR DESCRIPTION
The message for failing to find and load a language translator was
misleading.

There is no problem running Manuskript with the default English
language (no translation loaded).  The word **Warning** implied that
something was wrong with manuskript and could be confusing to users.