### PR TITLE
Fixes: Unable to change index cards background from image to a color

### DIFF
--- a/manuskript/functions.py
+++ b/manuskript/functions.py
@@ -226,12 +226,16 @@ def findWidgetsOfClass(cls):
 
 def findBackground(filename):
     """
-    Returns the full path to a background file of name filename within ressource folders.
+    Returns the full path to a background file of name filename within resources folders.
     """
     return findFirstFile(re.escape(filename), "resources/backgrounds")
 
 
 def findFirstFile(regex, path="resources"):
+    """
+    Returns full path of first file matching regular expression regex within folder path,
+    otherwise returns full path of last file in folder path.
+    """
     paths = allPaths(path)
     for p in paths:
         lst = os.listdir(p)

--- a/manuskript/settings.py
+++ b/manuskript/settings.py
@@ -50,7 +50,7 @@ outlineViewColumns = [Outline.title.value, Outline.POV.value, Outline.status.val
                       Outline.goalPercentage.value, Outline.label.value]
 corkBackground = {
     "color": "#926239",
-    "image": ""
+    "image": "writingdesk"
         }
 defaultTextType = "md"
 fullScreenTheme = "spacedreams"

--- a/manuskript/settingsWindow.py
+++ b/manuskript/settingsWindow.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import qApp
 from manuskript import settings
 from manuskript.enums import Outline
 from manuskript.functions import allPaths, iconColor, writablePath, appPath, findWidgetsOfClass
-from manuskript.functions import mainWindow
+from manuskript.functions import mainWindow, findBackground
 from manuskript.ui.editors.tabSplitter import tabSplitter
 from manuskript.ui.editors.themes import createThemePreview
 from manuskript.ui.editors.themes import getThemeName
@@ -371,7 +371,7 @@ class settingsWindow(QWidget, Ui_Settings):
 
     def setCorkImageDefault(self):
         if settings.corkBackground["image"] != "":
-            i = self.cmbCorkImage.findData(settings.corkBackground["image"])
+            i = self.cmbCorkImage.findData(findBackground(settings.corkBackground["image"]))
             if i != -1:
                 self.cmbCorkImage.setCurrentIndex(i)
 

--- a/manuskript/ui/views/corkView.py
+++ b/manuskript/ui/views/corkView.py
@@ -25,7 +25,11 @@ class corkView(QListView, dndView, outlineBasics):
         self.updateBackground()
 
     def updateBackground(self):
-        img = findBackground(settings.corkBackground["image"])
+        if settings.corkBackground["image"] != "":
+            img = findBackground(settings.corkBackground["image"])
+        else:
+            # No background image
+            img = ""
         self.setStyleSheet("""QListView {{
             background:{color};
             background-image: url({url});


### PR DESCRIPTION
See issue #52.

Enable selection of background color in addition to background image
for index cards.  This setting is accessed from the manuskript menu
**Edit -> Settings -> Views -> Index cards**.

Keep initial default of "writingdesk" background image for Index cards.

Also update comments for functions to better describe how these work.