### PR TITLE
Use QtWebEngine instead of deprecated QtWebView

### DIFF
--- a/manuskript/exporter/manuskript/HTML.py
+++ b/manuskript/exporter/manuskript/HTML.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # --!-- coding: utf8 --!--
 from PyQt5.QtCore import Qt, QUrl
-from PyQt5.QtWebKitWidgets import QWebView
+from PyQt5.QtWebEngineWidgets import QWebEngineView
 from PyQt5.QtWidgets import QPlainTextEdit, qApp, QTabWidget, QFrame
 
 from manuskript.exporter.manuskript.markdown import markdown, markdownSettings
@@ -50,7 +50,7 @@ class HTML(markdown):
         w1 = QPlainTextEdit()
         w1.setFrameShape(QFrame.NoFrame)
         w1.setReadOnly(True)
-        w2 = QWebView()
+        w2 = QWebEngineView()
         t.addTab(w0, qApp.translate("Export", "Markdown source"))
         t.addTab(w1, qApp.translate("Export", "HTML Source"))
         t.addTab(w2, qApp.translate("Export", "HTML Output"))
@@ -78,6 +78,3 @@ class HTML(markdown):
         self.preparesTextEditView(previewWidget.widget(1), settings["Preview"]["PreviewFont"])
         previewWidget.widget(1).setPlainText(html)
         previewWidget.widget(2).setHtml(html, QUrl.fromLocalFile(path))
-
-
-

--- a/manuskript/exporter/manuskript/HTML.py
+++ b/manuskript/exporter/manuskript/HTML.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # --!-- coding: utf8 --!--
 from PyQt5.QtCore import Qt, QUrl
-from PyQt5.QtWebEngineWidgets import QWebEngineView
-from PyQt5.QtWidgets import QPlainTextEdit, qApp, QTabWidget, QFrame
+from PyQt5.QtWidgets import QPlainTextEdit, qApp, QTabWidget, QFrame, QTextEdit
 
 from manuskript.exporter.manuskript.markdown import markdown, markdownSettings
+from manuskript.ui.views.webView import webView
 from manuskript.ui.exporters.manuskript.plainTextSettings import exporterSettings
 import os
 
@@ -50,10 +50,12 @@ class HTML(markdown):
         w1 = QPlainTextEdit()
         w1.setFrameShape(QFrame.NoFrame)
         w1.setReadOnly(True)
-        w2 = QWebEngineView()
         t.addTab(w0, qApp.translate("Export", "Markdown source"))
         t.addTab(w1, qApp.translate("Export", "HTML Source"))
-        t.addTab(w2, qApp.translate("Export", "HTML Output"))
+        
+        if webView:
+            w2 = webView()
+            t.addTab(w2, qApp.translate("Export", "HTML Output"))
 
         t.setCurrentIndex(2)
         return t
@@ -77,4 +79,8 @@ class HTML(markdown):
         previewWidget.widget(0).setPlainText(md)
         self.preparesTextEditView(previewWidget.widget(1), settings["Preview"]["PreviewFont"])
         previewWidget.widget(1).setPlainText(html)
-        previewWidget.widget(2).setHtml(html, QUrl.fromLocalFile(path))
+        w2 = previewWidget.widget(2)
+        if isinstance(w2, QTextEdit):
+            w2.setHtml(html)
+        else:
+            w2.setHtml(html, QUrl.fromLocalFile(path))

--- a/manuskript/exporter/pandoc/PDF.py
+++ b/manuskript/exporter/pandoc/PDF.py
@@ -4,7 +4,6 @@ import random
 import shutil
 
 from PyQt5.QtCore import QUrl
-from PyQt5.QtWebEngineWidgets import QWebEngineSettings, QWebEngineView
 from PyQt5.QtWidgets import qApp
 
 from manuskript.exporter.pandoc.abstractOutput import abstractOutput
@@ -18,7 +17,7 @@ class PDF(abstractOutput):
     name = "PDF"
     description = qApp.translate("Export", "Needs latex to be installed.")
     InvalidBecause = qApp.translate("Export", """a valid latex installation. See pandoc recommendations on:
-                     <a href="http://pandoc.org/installing.html">http://pandoc.org/installing.html</a>""")
+                     <a href="http://pandoc.org/installing.html">http://pandoc.org/installing.html</a>. If you want unicode support, you need xelatex.""")
     icon = "application-pdf"
 
     exportVarName = "lastPandocPDF"
@@ -30,13 +29,15 @@ class PDF(abstractOutput):
     }
 
     def isValid(self):
-        path = shutil.which("pdflatex")
+        path = shutil.which("pdflatex") or shutil.which("xelatex")
         return path is not None
 
     def output(self, settingsWidget, outputfile=None):
         args = settingsWidget.runnableSettings()
         args.remove("--to=pdf")
         args.append("--to=latex")
+        if shutil.which("xelatex"):
+            args.append("--latex-engine=xelatex")
         src = self.src(settingsWidget)
         return self.exporter.convert(src, args, outputfile)
 

--- a/manuskript/exporter/pandoc/PDF.py
+++ b/manuskript/exporter/pandoc/PDF.py
@@ -4,8 +4,7 @@ import random
 import shutil
 
 from PyQt5.QtCore import QUrl
-from PyQt5.QtWebKit import QWebSettings
-from PyQt5.QtWebKitWidgets import QWebView
+from PyQt5.QtWebEngineWidgets import QWebEngineSettings, QWebEngineView
 from PyQt5.QtWidgets import qApp
 
 from manuskript.exporter.pandoc.abstractOutput import abstractOutput

--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -4,7 +4,7 @@ import faulthandler
 import os
 import sys
 
-import PyQt5.QtWebEngineWidgets # must be imported before QApplication
+# import PyQt5.QtWebEngineWidgets # must be imported before QApplication
 from PyQt5.QtCore import QLocale, QTranslator, QSettings
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication, qApp

--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -4,6 +4,7 @@ import faulthandler
 import os
 import sys
 
+import PyQt5.QtWebEngineWidgets # must be imported before QApplication
 from PyQt5.QtCore import QLocale, QTranslator, QSettings
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication, qApp
@@ -21,7 +22,7 @@ def run():
     app.setOrganizationDomain("www.theologeek.ch")
     app.setApplicationName("manuskript")
     app.setApplicationVersion(_version)
-    
+
     print("Running manuskript version {}.".format(_version))
     icon = QIcon()
     for i in [16, 32, 64, 128, 256, 512]:

--- a/manuskript/ui/views/PDFViewer.py
+++ b/manuskript/ui/views/PDFViewer.py
@@ -2,19 +2,18 @@
 # --!-- coding: utf8 --!--
 from PyQt5.QtCore import QUrl
 from PyQt5.QtNetwork import QNetworkAccessManager
-from PyQt5.QtWebKit import QWebSettings
-from PyQt5.QtWebKitWidgets import QWebView, QWebPage
+from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage, QWebEngineSettings
 
 from manuskript.functions import appPath
 
 
-class PDFViewer(QWebView):
+class PDFViewer(QWebEngineView):
     pdf_viewer_page = "file://"+appPath('libs/pdf.js/web/viewer.html')
 
     def __init__(self, parent=None):
-        QWebView.__init__(self, parent)
-        self.settings = QWebSettings.globalSettings()
-        self.settings.setAttribute(QWebSettings.LocalContentCanAccessFileUrls, True)
+        QWebEngineView.__init__(self, parent)
+        self.settings = QWebEngineSettings.globalSettings()
+        self.settings.setAttribute(QWebEngineSettings.LocalContentCanAccessFileUrls, True)
 
     def loadPDF(self, pdf):
         url = QUrl(self.pdf_viewer_page+"?file="+pdf)

--- a/manuskript/ui/views/PDFViewer.py
+++ b/manuskript/ui/views/PDFViewer.py
@@ -1,21 +1,57 @@
 #!/usr/bin/env python
 # --!-- coding: utf8 --!--
 from PyQt5.QtCore import QUrl
-from PyQt5.QtNetwork import QNetworkAccessManager
-from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage, QWebEngineSettings
+from PyQt5.QtWidgets import QLabel
+from manuskript.ui.views.webView import webView, webEngine
 
 from manuskript.functions import appPath
 
 
-class PDFViewer(QWebEngineView):
-    pdf_viewer_page = "file://"+appPath('libs/pdf.js/web/viewer.html')
+if webEngine == "QtWebKit":
 
-    def __init__(self, parent=None):
-        QWebEngineView.__init__(self, parent)
-        self.settings = QWebEngineSettings.globalSettings()
-        self.settings.setAttribute(QWebEngineSettings.LocalContentCanAccessFileUrls, True)
+    from PyQt5.QtWebKit import QWebSettings
+    from PyQt5.QtWebKitWidgets import QWebView
 
-    def loadPDF(self, pdf):
-        url = QUrl(self.pdf_viewer_page+"?file="+pdf)
-        self.settings.clearMemoryCaches()
-        self.load(url)
+
+    class PDFViewer(QWebView):
+        pdf_viewer_page = "file://"+appPath('libs/pdf.js/web/viewer.html')
+
+        def __init__(self, parent=None):
+            QWebView.__init__(self, parent)
+            self.settings = QWebSettings.globalSettings()
+            self.settings.setAttribute(QWebSettings.LocalContentCanAccessFileUrls, True)
+
+        def loadPDF(self, pdf):
+            url = QUrl(self.pdf_viewer_page+"?file="+pdf)
+            self.settings.clearMemoryCaches()
+            self.load(url)
+
+
+elif webEngine == "QtWebEngine":
+
+    from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage, QWebEngineSettings
+
+
+    class PDFViewer(QWebEngineView):
+        pdf_viewer_page = "file://"+appPath('libs/pdf.js/web/viewer.html')
+
+        def __init__(self, parent=None):
+            QWebEngineView.__init__(self, parent)
+            self.settings = QWebEngineSettings.globalSettings()
+            self.settings.setAttribute(QWebEngineSettings.LocalContentCanAccessFileUrls, True)
+
+        def loadPDF(self, pdf):
+            url = QUrl(self.pdf_viewer_page+"?file="+pdf)
+            self.load(url)
+
+
+else:
+
+    class PDFViewer(QLabel):
+        def __init__(self, parent=None):
+            QLabel.__init__(self, parent)
+            self.setText("No Web Engine installed capable of displaying PDF.\n\n"
+                         "Consider installing QtWebKit or QtWebEngine.")
+
+        def loadPDF(self, pdf):
+            pass

--- a/manuskript/ui/views/webView.py
+++ b/manuskript/ui/views/webView.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# --!-- coding: utf8 --!--
+from PyQt5.QtWidgets import QTextEdit
+
+try:
+    from PyQt5.QtWebKitWidgets import QWebView
+    print("Debug: Web rendering engine used: QWebView")
+    webEngine = "QtWebKit"
+    webView = QWebView
+
+except:
+
+    try:
+        from PyQt5.QtWebEngineWidgets import QWebEngineView
+        print("Debug: Web rendering engine used: QWebEngineView")
+        webEngine = "QtWebEngine"
+        webView = QWebEngineView
+
+    except:
+        print("Debug: Web rendering engine used: QTextEdit")
+        webEngine = "QTextEdit"
+        webView = QTextEdit


### PR DESCRIPTION
As mentioned in #54, QtWebKit was deprecated and is now removed from Qt releases. Although there is apparently some effort being made to reinstate it, right now it results in complicated build process to get Manuscript working (see #35). And since it uses QtWebKit only to render HTML and PDF previews, it is fairly easy to rewrite it using QtWebKit's successor: QtWebEngine.

This PR makes it.

However, note that I only tested it with HTML preview now (it worked). I need to fix my LaTeX installation to test it with PDFs. Also, any clues on testing would be most welcome.

With QtWebEngine instead of QtWebKit, it's possible to build Manuscript against standard binary distribution of Qt from Homebrew and I suppose it's also easier on some Linux distributions. I don't have a chance right now to check it on Windows.