### PR TITLE
Fixes: add character button does not set importance slider to default…

### DIFF
--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -156,7 +156,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         """
         c = self.lstCharacters.currentCharacter()
         if not c:
-            self.tabPlot.setEnabled(False)
+            self.tabPersos.setEnabled(False)
             return
 
         self.tabPersos.setEnabled(True)

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -220,6 +220,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.sldPlotImportance.setCurrentModelIndex(index)
         self.lstPlotPerso.setRootIndex(index.sibling(index.row(),
                                                      Plot.characters.value))
+
+        # Slider importance
+        self.updatePlotImportance(index.row())
+
         subplotindex = index.sibling(index.row(), Plot.steps.value)
         self.lstSubPlots.setRootIndex(subplotindex)
         if self.mdlPlots.rowCount(subplotindex):
@@ -244,6 +248,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.lstSubPlots.horizontalHeader().setSectionResizeMode(
                 PlotStep.meta.value, QHeaderView.ResizeToContents)
         self.lstSubPlots.verticalHeader().hide()
+
+    def updatePlotImportance(self, ID):
+        imp = self.mdlPlots.getPlotImportanceByID(ID)
+        self.sldPlotImportance.setValue(int(imp))
 
     def changeCurrentSubPlot(self, index):
         # Got segfaults when using textEditView model system, so ad hoc stuff.

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -179,6 +179,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # Button color
         self.updateCharacterColor(c.ID())
 
+        # Slider importance
+        self.updateCharacterImportance(c.ID())
+
         # Character Infos
         self.tblPersoInfos.setRootIndex(index)
 
@@ -194,6 +197,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         c = self.mdlCharacter.getCharacterByID(ID)
         color = c.color().name()
         self.btnPersoColor.setStyleSheet("background:{};".format(color))
+
+    def updateCharacterImportance(self, ID):
+        c = self.mdlCharacter.getCharacterByID(ID)
+        self.sldPersoImportance.setValue(int(c.importance()))
 
     ###############################################################################
     # PLOTS

--- a/manuskript/models/plotModel.py
+++ b/manuskript/models/plotModel.py
@@ -55,6 +55,14 @@ class plotModel(QStandardItemModel):
                 return name
         return None
 
+    def getPlotImportanceByID(self, ID):
+        for i in range(self.rowCount()):
+            _ID = self.item(i, Plot.ID.value).text()
+            if _ID == ID or toInt(_ID) == ID:
+                importance = self.item(i, Plot.importance.value).text()
+                return importance
+        return "0" # Default to "Minor"
+
     def getSubPlotTextsByID(self, plotID, subplotRaw):
         """Returns a tuple (name, summary) for the suplot whose raw in the model
         is ``subplotRaw``, of plot whose ID is ``plotID``.


### PR DESCRIPTION
… value

See issue #102.

By default when a character is added to the character model, the
importance value is set to "0" (Minor).  However when the new
character is selected, the importance slider remains set to the value
of the previously selected character.

Steps to Reproduce:

1.  Click add character (plus sign) button.
2.  Select this "New character".
3.  Select "Basic infos" tab and change Name to "Bob".
4.  Move Importance slider all the way to the right (Main).
5.  Click add character (plus sign) button.
6.  Select this "New character".

    Note that the "New character" is shown in the character list pane
    under "Minor", but the Importance slider is still all the way to
    the right (Main).

This enhancement ensures that the corresponding character UI
importance slider is also set to the same default value.

This enhancement aligns the Character importance slider with the way the Plot importance slider works.  More specifically all new records are added at the lowest importance level.