### PR TITLE
Fixes: Contents missing when non-single file project saved with Save as

### DIFF
--- a/manuskript/ui/welcome.py
+++ b/manuskript/ui/welcome.py
@@ -10,6 +10,7 @@ from PyQt5.QtGui import QIcon, QBrush, QColor, QStandardItemModel, QStandardItem
 from PyQt5.QtWidgets import QWidget, QAction, QFileDialog, QSpinBox, QLineEdit, QLabel, QPushButton, QTreeWidgetItem, \
     qApp, QMessageBox
 
+from manuskript import loadSave
 from manuskript import settings
 from manuskript.enums import Outline
 from manuskript.functions import mainWindow, iconFromColor, appPath
@@ -142,7 +143,13 @@ class welcome(QWidget, Ui_welcome):
 
         if filename:
             self.appendToRecentFiles(filename)
+            loadSave.clearSaveCache()  # Ensure all file(s) are saved under new filename
             self.mw.saveDatas(filename)
+            # Update Window's project name with new filename
+            pName = os.path.split(filename)[1]
+            if pName.endswith('.msk'):
+                pName=pName[:-4]
+            self.mw.setWindowTitle(pName + " - " + self.tr("Manuskript"))
 
     def createFile(self):
         """When starting a new project, ask for a place to save it.


### PR DESCRIPTION
See issue #128.

With the "Save to one single file" setting **disabled** (accessible
via "Edit -> Settings" under the General tab), then using
"File -> Save as..." creates only a portion of the previous project
files and content.

Steps to Reproduce:

1.  Open or create project with data (characters, plots, outline, etc.)
2.  Ensure existing project is saved with "File -> Save".
3.  Choose "File -> Save as..."
4.  Enter a new filename and click Save button.
5.  Choose "File -> Close Project"
6.  Choose "File -> Open" and choose the newly created project filename.

    Note that most of the project contents are missing or empty
    (plots, outline, etc.).

This enhancement disables smart caching for the first save of the new
project filename so that all project files are saved under the new
filename.