### PR TITLE
Add to README a HowTo section with link to Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ Optional:
 - Debian based (Ubuntu, Linux Mint, etc.):
 ```sudo apt-get install python3-pyqt5 libqt5svg5 python3-lxml python3-enchant zlib1g```  
   Additional packages that might be needed: ``python3-pyqt5.qtwebkit pyqt5-dev-tools``
+
+## HowTo's
+
+See the [Wiki](http://github.com/olivierkes/manuskript/wiki) for more
+detailed instructions on how to install on GNU/Linux, Windows, and OS X.


### PR DESCRIPTION
Add to the README.md file a HowTo's section with a link to the Manuskript Wiki.

The purpose of this enhancement is to increase the visibility of the Wiki and ultimately help users to install and run Manuskript.

@olivierkes if you have a chance it might be a good idea to update the [CHANGELOG.md](https://github.com/olivierkes/manuskript/blob/master/CHANGELOG.md) file as well.  The last entry is for version 0.2.0.