### PR TITLE
Fixes: Manuskript fails to load last state of panels

### DIFF
--- a/manuskript/ui/collapsibleDockWidgets.py
+++ b/manuskript/ui/collapsibleDockWidgets.py
@@ -101,7 +101,9 @@ class collapsibleDockWidgets(QToolBar):
     def restoreState(self, state):
         for group, title, status in state:
             for btn, act, widget, grp in self.otherWidgets:
-                if group == grp and title == btn.text():
+                # Strip '&' from both title and btn.text() to improve matching because
+                #   title contains "&" shortcut character whereas btn.text() does not.
+                if group == grp and title.replace('&', '') == btn.text().replace('&', ''):
                     btn.setChecked(status)
                     widget.setVisible(status)
 


### PR DESCRIPTION
See issue #14.

Four panels use custom widgets on the Right-Hand-Side tabs to control
visibility.  These panels are:

```
  PANEL NAME     VIEWABLE ON NAVIGATION TAB
  ------------   --------------------------
  Book summary   Plots
  Project tree   Redaction
  Metadata       Redaction
  Story line     Redaction
```

When the custom widget is created, it is assigned a name that is
marked for translation.  The final text name appears to have a
shortcut letter automatically assigned.  For example in English:

```
  Book summary   ->   B&ook summary
  Project tree   ->   &Project tree
  Metadata       ->   &Metadata
  Story line     ->   Story &line
```

On restoration the choice to restore state is based on successful
comparison between title and btn.text().  Currently this comparison
fails because title contains "&" and btn.text() does not contain "&".

Fix by removing all ampersand "&" characters from both title and
btn.text() when performing comparison.