### PR TITLE
Compile without open project causes a crash

### DIFF
--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -6,7 +6,7 @@ import os
 from PyQt5.QtCore import pyqtSignal, QSignalMapper, QTimer, QSettings, Qt, QRegExp, QUrl, QSize
 from PyQt5.QtGui import QStandardItemModel, QIcon, QColor
 from PyQt5.QtWidgets import QMainWindow, QHeaderView, qApp, QMenu, QActionGroup, QAction, QStyle, QListWidgetItem, \
-    QLabel
+    QLabel, QMessageBox
 
 from manuskript import settings
 from manuskript.enums import Character, PlotStep, Plot, World, Outline
@@ -1217,10 +1217,13 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     ###############################################################################
 
     def doCompile(self):
-        self.dialog = exporterDialog(mw=self)
-        self.dialog.show()
+        if self.currentProject is not None:
+            self.dialog = exporterDialog(mw=self)
+            self.dialog.show()
 
-        r = self.dialog.geometry()
-        r2 = self.geometry()
-        self.dialog.move(r2.center() - r.center())
+            r = self.dialog.geometry()
+            r2 = self.geometry()
+            self.dialog.move(r2.center() - r.center())
+        else:
+            QMessageBox.critical(self, "Cannot compile", "No project selected")
 


### PR DESCRIPTION
Hello. I found a little bug and I enclose a solution to it.

**Steps to reproduce:**

1. Be on `develop` branch
2. Open an application
3. On project selection window without selecting a project press F6 or select File->Compile

**Expected result:**

Some alert that compilation is not possible without selecting a project

**Actual result:**

Application crashes with following stacktrace:

```
Traceback (most recent call last):
  File "/Users/pawel/dev/github/manuskript/bin/../manuskript/ui/exporters/exporter.py", line 76, in updateUi
    self.settingsWidget = F.settingsWidget()
  File "/Users/pawel/dev/github/manuskript/bin/../manuskript/exporter/manuskript/plainText.py", line 32, in settingsWidget
    w = exporterSettings(self)
  File "/Users/pawel/dev/github/manuskript/bin/../manuskript/ui/exporters/manuskript/plainTextSettings.py", line 32, in __init__
    self.contentUpdateTable()
  File "/Users/pawel/dev/github/manuskript/bin/../manuskript/ui/exporters/manuskript/plainTextSettings.py", line 338, in contentUpdateTable
    level = self.mw.mdlOutline.maxLevel()
AttributeError: 'MainWindow' object has no attribute 'mdlOutline'
Fatal Python error: Aborted

Current thread 0x00007fffd17633c0 (most recent call first):
  File "/Users/pawel/dev/github/manuskript/bin/../manuskript/ui/exporters/exporter.py", line 32 in __init__
  File "/Users/pawel/dev/github/manuskript/bin/../manuskript/mainWindow.py", line 1220 in doCompile
  File "/Users/pawel/dev/github/manuskript/bin/../manuskript/main.py", line 73 in launch
  File "/Users/pawel/dev/github/manuskript/bin/../manuskript/main.py", line 64 in run
  File "bin/manuskript", line 13 in <module>
[1]    19720 abort      bin/manuskript
```

The message should probably be translated, but frankly I don't know how to do that and I didn't find information in the wiki.