### PR TITLE
Add PyEnchant support to OSX builds

### DIFF
--- a/package/prepare_osx.sh
+++ b/package/prepare_osx.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -ev
 brew update
-brew install python3 # enchant
+brew install python3 enchant
 sudo pip3 install --upgrade pip setuptools wheel
-pip3 install pyinstaller PyQt5 lxml # pyenchant
-# brew install qt hunspell
+pip3 install pyinstaller PyQt5 lxml pyenchant
+brew install qt hunspell
 # fooling PyEnchant as described in the wiki: https://github.com/olivierkes/manuskript/wiki/Package-manuskript-for-OS-X
-# sudo touch /usr/local/share/aspell
+sudo touch /usr/local/share/aspell


### PR DESCRIPTION
After fixing #188 PyEnchant builds pass and seem to generate working build with spellcheck enabled.