### PR TITLE
Build MacOS release with XCode 7.3 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: cpp
 os:
 - osx
+osx_image: xcode7.3
 sudo: required
 install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/prepare_osx.sh; fi


### PR DESCRIPTION
7.3 is the oldest image available on TravisCI that works. Older 6.4 version does not play well with Enchant, resulting in a build error. This could probably be averted by trying to build with 6.4 and without Enchant support, but I'm not sure if it's worth it.

Relates to #282, tested with El Capitan and Sierra.