### PR TITLE
Skip loading directory and file names that begin with a period

### DIFF
--- a/manuskript/load_save/version_1.py
+++ b/manuskript/load_save/version_1.py
@@ -647,7 +647,13 @@ def loadProject(project, zip=None):
         files = {}
         for dirpath, dirnames, filenames in os.walk(path):
             p = dirpath.replace(path, "")
+            # Skip directories that begin with a period
+            if p[:1] == ".":
+                continue
             for f in filenames:
+                # Skip filenames that begin with a period
+                if f[:1] == ".":
+                    continue
                 # mode = "r" + ("b" if f[-4:] in [".xml", "opml"] else "")
                 if f[-4:] in [".xml", "opml"]:
                     with open(os.path.join(dirpath, f), "rb") as fo:


### PR DESCRIPTION
See issue #281.

When loading a project that has the setting **Save to one single
file** disabled, Manuskript tries to read all directories and files
under the project directory.

Manuskript expects all files to contain valid unicode characters.

However if a file containing non-unicode characters is read then
Manuskript will crash.

The error message displayed on the console is similar to the
following:

----- begin snippet -----
```
Traceback (most recent call last):
  File "/home/gedakc/workspace/manuskript.olivierkes/bin/../manuskript/ui/welcome.py", line 134, in loadRecentFile
    self.mw.loadProject(act.data())
  File "/home/gedakc/workspace/manuskript.olivierkes/bin/../manuskript/mainWindow.py", line 566, in loadProject
    self.loadDatas(project)
  File "/home/gedakc/workspace/manuskript.olivierkes/bin/../manuskript/mainWindow.py", line 793, in loadDatas
    errors = loadSave.loadProject(project)
  File "/home/gedakc/workspace/manuskript.olivierkes/bin/../manuskript/loadSave.py", line 66, in loadProject
    v1.loadProject(project, zip=isZip)
  File "/home/gedakc/workspace/manuskript.olivierkes/bin/../manuskript/load_save/version_1.py", line 657, in loadProject
    files[os.path.join(p, f)] = fo.read()
  File "/usr/lib/python3.5/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 3131: invalid start byte
```
----- end snippet -----

There are at least two known situations in which files with
non-unicode characters can arise:

A. The project is on Mac OS X and the operating system automatically
   creates a .DS_Store file.

B. The project is under git version control and contains a .git
   subdirectory.

This enhancement prevents the Manuskript crash on project load by
ignoring all directory and file names that start with a period.
