### PR TITLE
Avoid crash on spellcheck by ensuring enchant dictionary exists

### DIFF
--- a/manuskript/ui/views/textEditView.py
+++ b/manuskript/ui/views/textEditView.py
@@ -427,14 +427,15 @@ class textEditView(QTextEdit):
 
     def setDict(self, d):
         self.currentDict = d
-        self._dict = enchant.Dict(d)
+        if d and enchant.dict_exists(d):
+            self._dict = enchant.Dict(d)
         if self.highlighter:
             self.highlighter.rehighlight()
 
     def toggleSpellcheck(self, v):
         self.spellcheck = v
         if enchant and self.spellcheck and not self._dict:
-            if self.currentDict:
+            if self.currentDict and enchant.dict_exists(self.currentDict):
                 self._dict = enchant.Dict(self.currentDict)
             elif enchant.get_default_language() and enchant.dict_exists(enchant.get_default_language()):
                 self._dict = enchant.Dict(enchant.get_default_language())


### PR DESCRIPTION
See issue #273.

@olivierkes do you think we should also test for dictionary existence in [textEditView::setDict(self, d)](https://github.com/olivierkes/manuskript/blob/dc9d67e8890e44d1c8d3fecc14c6b469552b4570/manuskript/ui/views/textEditView.py#L428), or is this only called using a known to exist dictionary listed in the GUI?

