### PR TITLE
Make word match for spell check exclude underscore from words

### DIFF
--- a/manuskript/ui/highlighters/basicHighlighter.py
+++ b/manuskript/ui/highlighters/basicHighlighter.py
@@ -146,8 +146,9 @@ class BasicHighlighter(QSyntaxHighlighter):
             textedText = text + " "
 
         # Based on http://john.nachtimwald.com/2009/08/22/qplaintextedit-with-in-line-spell-check/
-        WORDS = r'(?iu)([\w\']+)[^\'\w]'
-        #        (?iu) means case insensitive and unicode
+        WORDS = r'(?iu)(((?!_)[\w\'])+)'
+        #         (?iu) means case insensitive and Unicode
+        #                (?!_) means perform negative lookahead to exclude "_" from pattern match.  See issue #283
         if hasattr(self.editor, "spellcheck") and self.editor.spellcheck:
             for word_object in re.finditer(WORDS, textedText):
                 if (self.editor._dict


### PR DESCRIPTION
See issue #283.

Adds (?!_) to perform negative lookahead to exclude "\_" from pattern match.

https://stackoverflow.com/questions/14858346/regular-expressions-how-to-express-w-without-underscore

Following are example screen shots before and after applying this patch.

**Before** patch which shows words with underscores falsely identified as spelling errors:

---
![manuskript-before-patch](https://user-images.githubusercontent.com/10405019/36282924-fb41a0b2-125f-11e8-88bb-c5831cec8123.png)

---

**After** patch which correctly identifies spelling errors:

---
![manuskript-after-patch](https://user-images.githubusercontent.com/10405019/36282955-169f771c-1260-11e8-98a1-501251f1147c.png)

---
