### PR TITLE
stop crash when click btnGoUp and current editor is None

### DIFF
--- a/manuskript/ui/editors/mainEditor.py
+++ b/manuskript/ui/editors/mainEditor.py
@@ -197,8 +197,9 @@ class mainEditor(QWidget, Ui_mainEditor):
             self.setCurrentModelIndex(i, newTab)
 
     def goToParentItem(self):
-        idx = self.currentEditor().currentIndex
-        self.mw.treeRedacOutline.setCurrentIndex(idx.parent())
+        if self.currentEditor():
+            idx = self.currentEditor().currentIndex
+            self.mw.treeRedacOutline.setCurrentIndex(idx.parent())
 
     def setCurrentModelIndex(self, index, newTab=False, tabWidget=None):
 


### PR DESCRIPTION
When click in Go to parent. Before any chapters where made. Crashes program.