### PR TITLE
Fix Travix CI build error on OSX installing python3

### DIFF
--- a/package/prepare_osx.sh
+++ b/package/prepare_osx.sh
@@ -4,7 +4,7 @@ brew update
 # upgrade to python 3.x
 brew upgrade python
 brew install enchant
-sudo pip3 install --upgrade pip setuptools wheel
+sudo -H pip3 install --upgrade pip setuptools wheel
 pip3 install pyinstaller PyQt5 lxml pyenchant
 brew install qt hunspell
 # fooling PyEnchant as described in the wiki: https://github.com/olivierkes/manuskript/wiki/Package-manuskript-for-OS-X

--- a/package/prepare_osx.sh
+++ b/package/prepare_osx.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -ev
 brew update
-brew install python3 enchant
+# upgrade to python 3.x
+brew upgrade python
+brew install enchant
 sudo pip3 install --upgrade pip setuptools wheel
 pip3 install pyinstaller PyQt5 lxml pyenchant
 brew install qt hunspell


### PR DESCRIPTION
This Pull Request is a Work-In-Progress until the Travis CI builds are able to complete successfully.

Following is the initial commit message for this PR.


The Travis CI builds have been failing with the following message:

    The command "if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/prepare_osx.sh; fi" failed and exited with 1 during .

This above line of code is from .travis.yml.  Further examination of
the log from executing package/prepare_osx.sh shows the following
message:

    <snip>
    brew install python3 enchant
    Error: python 2.7.12_1 is already installed
    To upgrade to 3.6.5, run `brew upgrade python`
    <snip>

Based on this message it appears that the method to install python3
has changed.  Hence change to command to upgrade python 2.x to 3.x.
