### PR TITLE
Fix Travis CI build for Mac OSX - pip3: command not found

### DIFF
--- a/package/prepare_osx.sh
+++ b/package/prepare_osx.sh
@@ -4,6 +4,7 @@ brew update
 # upgrade to python 3.x
 brew upgrade python
 brew install enchant
+brew postinstall python # this installs pip
 sudo -H pip3 install --upgrade pip setuptools wheel
 pip3 install pyinstaller PyQt5 lxml pyenchant
 brew install qt hunspell


### PR DESCRIPTION
It seems that the homebrew recipes for python3 and pip3 installation for Mac OS X are subject to ongoing changes.  This fix addresses a recent change to the recipe for installing python3 and pip3.