### PR TITLE
Enable testing in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
-language: cpp
+language: generic
 os:
 - osx
+- linux
 osx_image: xcode7.3
 sudo: required
 install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/prepare_osx.sh; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash package/prepare_linux.sh; fi
 script:
-- python3 package/dependency_test.py
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then python3 -m pytest -vs; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run -s '-screen 0 640x480x24 +extension GLX' pytest -vs; fi
 before_deploy:
 - export FILENAME=manuskript-$TRAVIS_BRANCH-$TRAVIS_OS_NAME.zip
 - pyinstaller manuskript.spec --clean

--- a/package/dependency_test.py
+++ b/package/dependency_test.py
@@ -1,8 +1,0 @@
-import os
-import sys
-
-realpath = os.path.realpath(__file__)
-
-sys.path.insert(1, os.path.join(os.path.dirname(realpath), '..'))
-
-from manuskript import main

--- a/package/prepare_linux.sh
+++ b/package/prepare_linux.sh
@@ -1,0 +1,7 @@
+sudo apt-get -qq update
+sudo apt-get -qq install python3-pip python3-dev build-essential qt5-default libxml2-dev libxslt1-dev mesa-utils libgl1-mesa-glx libgl1-mesa-dev
+
+pyenv local 3.6.3
+python --version
+easy_install pip
+pip install pyqt5==5.9 lxml pytest pytest-faulthandler

--- a/package/prepare_osx.sh
+++ b/package/prepare_osx.sh
@@ -6,7 +6,7 @@ brew upgrade python
 brew install enchant
 brew postinstall python # this installs pip
 sudo -H pip3 install --upgrade pip setuptools wheel
-pip3 install pyinstaller PyQt5 lxml pyenchant
+pip3 install pyinstaller PyQt5 lxml pyenchant pytest pytest-faulthandler
 brew install qt hunspell
 # fooling PyEnchant as described in the wiki: https://github.com/olivierkes/manuskript/wiki/Package-manuskript-for-OS-X
 sudo touch /usr/local/share/aspell


### PR DESCRIPTION
As we talked in #402, since right now we have no control over SemaphoreCI and tests there are segfaulting and it would be nice to have tests in CI, this pull requests adds running tests on TravisCI.

~Right now they are "correctly failing" because of bug #381, which was not caught in CI because of aforementioned segmentation faults in Semaphore. Depending on what we want, we might skip those tests for now, allow them to fail or merge #401 (but it should be tested first).~

With this PR tests are run on Linux and MacOS. I also discovered that there is experimental support for testing on Windows on Travis since few weeks, but maybe that's an idea for the future.