### PR TITLE
Fix plot importance changes if delete earlier plot and click other plots

### DIFF
--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -417,8 +417,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 PlotStep.meta, QHeaderView.ResizeToContents)
         self.lstSubPlots.verticalHeader().hide()
 
-    def updatePlotImportance(self, ID):
-        imp = self.mdlPlots.getPlotImportanceByID(ID)
+    def updatePlotImportance(self, row):
+        imp = self.mdlPlots.getPlotImportanceByRow(row)
         self.sldPlotImportance.setValue(int(imp))
 
     def changeCurrentSubPlot(self, index):

--- a/manuskript/models/plotModel.py
+++ b/manuskript/models/plotModel.py
@@ -68,10 +68,9 @@ class plotModel(QStandardItemModel):
                 return name
         return None
 
-    def getPlotImportanceByID(self, ID):
+    def getPlotImportanceByRow(self, row):
         for i in range(self.rowCount()):
-            _ID = self.item(i, Plot.ID).text()
-            if _ID == ID or toInt(_ID) == ID:
+            if i == row:
                 importance = self.item(i, Plot.importance).text()
                 return importance
         return "0" # Default to "Minor"


### PR DESCRIPTION
The root cause was a mismatch between plot IDs and plot model rows.

This issue would appear when a plot was deleted such that the plot IDs
did not match the plot model row numbers and different plots had
different importance levels.  The problem would not occur if the most
recently added plot was deleted.

For test steps see issue #404.

If someone has a chance to test this patch then I would greatly appreciate it.

I will hold off on merging this patch for a few days to wait for feedback.