### PR TITLE
Fix segmentation fault on import

### DIFF
--- a/manuskript/ui/importers/importer.py
+++ b/manuskript/ui/importers/importer.py
@@ -36,6 +36,7 @@ class importerDialog(QWidget, Ui_importer):
 
         # Var
         self.mw = mw
+        self.settingsWidget = None
         self.fileName = ""
         self.setStyleSheet(style.mainWindowSS())
         self.tree.setStyleSheet("QTreeView{background:transparent;}")
@@ -196,7 +197,7 @@ class importerDialog(QWidget, Ui_importer):
 
         self.settingsWidget = generalSettings()
         #TODO: custom format widget
-        self.settingsWidget = F.settingsWidget(self.settingsWidget)
+        # self.settingsWidget = F.settingsWidget(self.settingsWidget)
 
         # Set the settings widget in place
         self.setGroupWidget(self.grpSettings, self.settingsWidget)


### PR DESCRIPTION
Fix the problem with Manuskript encountering a segmentation fault when import is invoked.  The segmentation fault also occurs with the automated pytest scripts.  Note that the segmentation fault began occurring with Qt 5.11.
