### PR TITLE
Limit pyinstaller package build and deploy to osx on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,7 @@ script:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run -s '-screen 0 640x480x24 +extension GLX' pytest -vs; fi
 before_deploy:
 - export FILENAME=manuskript-$TRAVIS_BRANCH-$TRAVIS_OS_NAME.zip
-- pyinstaller manuskript.spec --clean
-- cd dist && zip $FILENAME -r manuskript && cd ..
-- ls dist
-- cp dist/$FILENAME dist/manuskript-osx-develop.zip
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/build_osx.sh; fi
 deploy:
   - provider: releases
     api_key:
@@ -24,11 +21,13 @@ deploy:
     overwrite: true
     skip_cleanup: true
     on:
+        os: osx
         tags: true
   - provider: script
     script: "curl -T dist/manuskript-osx-develop.zip -u hfpn_semaphoreci:$FTP_PASSWORD ftp://www.theologeek.ch/web/manuskript/releases/ -v"
     skip_cleanup: true
     on:
+        os: osx
         branch: develop
 env:
   global:

--- a/package/build_osx.sh
+++ b/package/build_osx.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ev
+if [ z"$FILENAME" = "z" ]; then
+    echo "Error:  Environment variable FILENAME is not set"
+    exit 1
+fi
+pyinstaller manuskript.spec --clean
+cd dist && zip $FILENAME -r manuskript && cd ..
+ls dist
+cp dist/$FILENAME dist/manuskript-osx-develop.zip


### PR DESCRIPTION
Currently the Travis CI build and deploy is failing on linux.  This started to occur when we added linux pytest to Travis CI.   The issue is that the exact same set of build and deploy instructions are running on linux when these were only meant to be run on osx.

Pytest was added to Travis CI for Linux with the following commit:

Enable testing in Travis CI
b50d6273335b9be8403941d1004df189d1008f72

Fix by adding constraints and conditions to limit the pyinstall build and deploy steps to osx only.