### PR TITLE
Add support for pandoc version 2

### DIFF
--- a/manuskript/exporter/pandoc/__init__.py
+++ b/manuskript/exporter/pandoc/__init__.py
@@ -67,6 +67,9 @@ class pandocExporter(basicExporter):
             if var and item and item.text().strip():
                 args.append("--variable={}:{}".format(var, item.text().strip()))
 
+        # Add title metatadata required for pandoc >= 2.x
+        args.append("--metadata=title:{}".format(mainWindow().mdlFlatData.item(0, 0).text().strip()))
+
         qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
 
         p = subprocess.Popen(


### PR DESCRIPTION
Pandoc version 2 deprecated some command line options and added others.

Prior to this enhancement, using pandoc to compile/export to PDF would fail.

This enhancement enables support for both pandoc v1 and v2.

See issue #304.