### PR TITLE
Increase Travis CI macOS X build minimum to Sierra (10.12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@ language: generic
 os:
 - osx
 - linux
-osx_image: xcode7.3
+osx_image: xcode8.3
 sudo: required
 install:
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/prepare_osx.sh; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash package/prepare_linux.sh; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then package/prepare_osx.sh; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then package/prepare_linux.sh; fi
 script:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then python3 -B -m pytest -vs; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run -s '-screen 0 640x480x24 +extension GLX' pytest -vs; fi
 before_deploy:
 - export FILENAME=manuskript-$TRAVIS_BRANCH-$TRAVIS_OS_NAME.zip
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/build_osx.sh; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then package/build_osx.sh; fi
 deploy:
   - provider: releases
     api_key:

--- a/package/prepare_linux.sh
+++ b/package/prepare_linux.sh
@@ -1,5 +1,9 @@
+#!/bin/bash
+set -ev   # display each line executed along with output
 sudo apt-get -qq update
-sudo apt-get -qq install python3-pip python3-dev build-essential qt5-default libxml2-dev libxslt1-dev mesa-utils libgl1-mesa-glx libgl1-mesa-dev
+sudo apt-get -qq install python3-pip python3-dev \
+     build-essential qt5-default libxml2-dev libxslt1-dev \
+     mesa-utils libgl1-mesa-glx libgl1-mesa-dev
 
 pyenv local 3.6.3
 python --version

--- a/package/prepare_osx.sh
+++ b/package/prepare_osx.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
-set -ev
+set -ev   # display each line executed along with output
 brew update
-# upgrade to python 3.x
+# Upgrade to python 3.x
 brew upgrade python
 brew install enchant
-brew postinstall python # this installs pip
+brew postinstall python   # this installs pip
 sudo -H pip3 install --upgrade pip setuptools wheel
 pip3 install pyinstaller PyQt5 lxml pyenchant pytest pytest-faulthandler
-brew install qt hunspell
-# fooling PyEnchant as described in the wiki: https://github.com/olivierkes/manuskript/wiki/Package-manuskript-for-OS-X
+brew install hunspell
+# Fooling PyEnchant as described in the wiki.
+#   https://github.com/olivierkes/manuskript/wiki/Package-manuskript-for-OS-X
 sudo touch /usr/local/share/aspell
+#
+# Note that if qt install is terminated by Travis CI then it is likely
+#   building from source instead of pouring from a homebrew bottle.
+#   Fix by choosing lowest osx_image value [1] for xcode that has a
+#   homebrew qt bottle [2].
+#   [1] https://docs.travis-ci.com/user/reference/osx#os-x-version
+#   [2] https://formulae.brew.sh/formula/qt
+brew install qt


### PR DESCRIPTION
Remove support for macOS X El Capitan (10.11) in Travis CI build

The Travis CI builds for macOS X are failing because these now timeout.  This happens because qt is being built from source instead of being installed from a bottle.

Note that by default the Travis CI will terminate a build after 10 minutes if no output has been received.  Unfortunately building qt from source code may take hours.

To address this issue, choose a macOS X version that has a homebrew bottle for qt [1].

[1] https://formulae.brew.sh/formula/qt

The homebrew project currently lists having a qt bottle for:

  - Mojave (10.14)
  - High Sierra (10.13)
  - Sierra (10.12)

No bottle is listed for macOS El Capitan (10.11)

In order to support as many versions of macOS X as possible, choose the lowest osx_image value [2] that is currently supported with a homebrew bottle.

[2] https://docs.travis-ci.com/user/reference/osx#os-x-version

At this time osx_image value xcode8.3 is listed as supporting OS X 10.12 (Sierra).

