### PR TITLE
add a requirement file example

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+python-qt5
+lxml
+webkit
+pyenchant
+markdown


### PR DESCRIPTION
I created a requirements file as requested by issue #449.

This file does not work, as python-qt5 returns this error after execution of `pip3 -r install requirements.txt`

`Files/directories not found in /tmp/pip-install-[path]/python-qt5/pip-egg-info`