### PR TITLE
Fix wrong codepage crash on import with Windows 10

### DIFF
--- a/manuskript/exporter/manuskript/plainText.py
+++ b/manuskript/exporter/manuskript/plainText.py
@@ -60,7 +60,7 @@ class plainText(basicFormat):
             filename = ""
 
         filename, filter = QFileDialog.getSaveFileName(settingsWidget.parent(),
-                                                       caption=qApp.translate("Export", "Chose output file..."),
+                                                       caption=qApp.translate("Export", "Choose output file..."),
                                                        filter=filter,
                                                        directory=filename)
 

--- a/manuskript/importer/markdownImporter.py
+++ b/manuskript/importer/markdownImporter.py
@@ -63,7 +63,7 @@ class markdownImporter(abstractImporter):
 
         if not fromString:
             # Read file
-            with open(filePath, "r") as f:
+            with open(filePath, "r", encoding="utf-8") as f:
                 txt = f.read()
         else:
             txt = fromString

--- a/manuskript/ui/importers/importer_ui.py
+++ b/manuskript/ui/importers/importer_ui.py
@@ -97,7 +97,7 @@ class Ui_importer(object):
         _translate = QtCore.QCoreApplication.translate
         importer.setWindowTitle(_translate("importer", "Import"))
         self.label.setText(_translate("importer", "Format:"))
-        self.btnChoseFile.setText(_translate("importer", "Chose file"))
+        self.btnChoseFile.setText(_translate("importer", "Choose file"))
         self.btnClearFileName.setToolTip(_translate("importer", "Clear file"))
         self.btnPreview.setText(_translate("importer", "Preview"))
         self.btnImport.setText(_translate("importer", "Import"))

--- a/manuskript/ui/importers/importer_ui.ui
+++ b/manuskript/ui/importers/importer_ui.ui
@@ -42,7 +42,7 @@
      <item>
       <widget class="QPushButton" name="btnChoseFile">
        <property name="text">
-        <string>Chose file</string>
+        <string>Choose file</string>
        </property>
        <property name="icon">
         <iconset theme="document-import"/>


### PR DESCRIPTION
This PR should address the problem reported in issue #470.

Also fixed is a spelling mistake that was noted in the issue report.