### PR TITLE
Try to fix macOS X blank screen when leaving editor fullscreen mode

### DIFF
--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -120,6 +120,10 @@ class fullScreenEditor(QWidget):
         # self.showMaximized()
         # self.show()
 
+    def __del__(self):
+        # print("Leaving fullScreenEditor via Destructor event", flush=True)
+        self.showNormal()
+
     def setLocked(self, val):
         self._locked = val
         self.btnClose.setVisible(not val)
@@ -221,6 +225,8 @@ class fullScreenEditor(QWidget):
     def keyPressEvent(self, event):
         if event.key() in [Qt.Key_Escape, Qt.Key_F11] and \
                 not self._locked:
+            # print("Leaving fullScreenEditor via keyPressEvent", flush=True)
+            self.showNormal()
             self.close()
         else:
             QWidget.keyPressEvent(self, event)


### PR DESCRIPTION
Ensure showNormal() is called after leaving showFullScreen().

See issue #24.

References:

https://stackoverflow.com/questions/31666744/pyqt5-can-not-close-a-topmost-fullscreen-qdialog-on-mac-osx

https://doc.qt.io/qt-5/qwidget.html#showFullScreen
  - To return from full-screen mode, call showNormal().

https://pythonprogramminglanguage.com/destructor/

Note that these changes have been tested on Kubuntu 16.04 GNU/Linux and Windows XP with no adverse effects observed.