### PR TITLE
Fix crash when 7 pound signs are written alone on a line.

### DIFF
--- a/manuskript/ui/highlighters/markdownTokenizer.py
+++ b/manuskript/ui/highlighters/markdownTokenizer.py
@@ -279,7 +279,9 @@ class MarkdownTokenizer(HighlightTokenizer):
 
         if level > 0 and level < len(text):
             # Count how many pound signs are at the end of the text.
-            while escapedText[-trailingPoundCount -1] == "#":
+            # Ignore starting pound signs when calculating trailing signs
+            while level + trailingPoundCount < len(text) and \
+                    escapedText[-trailingPoundCount -1] == "#":
                 trailingPoundCount += 1
 
             token = Token()


### PR DESCRIPTION
Re-submitting PR #483.

Easy to reproduce, enter 7 pound signs on a line with no trailing text and as soon as the 7th is entered, manuskript would crash.

The code would look for trailing pound signs and would count all the way to the beginning and beyond, resulting in an out of bounds exception.
Fix was to make sure not to include the starting pound signs when counting the trailing ones.
