### PR TITLE
Don't crash if a typo is made in the exporter's regular expression.

### DIFF
--- a/manuskript/exporter/manuskript/plainText.py
+++ b/manuskript/exporter/manuskript/plainText.py
@@ -2,7 +2,7 @@
 # --!-- coding: utf8 --!--
 import re
 from PyQt5.QtGui import QFont, QTextCharFormat
-from PyQt5.QtWidgets import QPlainTextEdit, qApp, QFrame, QFileDialog
+from PyQt5.QtWidgets import QPlainTextEdit, qApp, QFrame, QFileDialog, QMessageBox
 
 from manuskript.exporter.basic import basicFormat
 from manuskript.functions import mainWindow
@@ -41,7 +41,12 @@ class plainText(basicFormat):
 
     def output(self, settingsWidget):
         settings = settingsWidget.getSettings()
-        return self.concatenate(mainWindow().mdlOutline.rootItem, settings)
+        try:
+            return self.concatenate(mainWindow().mdlOutline.rootItem, settings)
+        except re.error as e:
+            QMessageBox.warning(mainWindow().dialog, qApp.translate("Export", "Error"),
+                                qApp.translate("Export", "Error processing regular expression : \n{}").format(str(e)))
+            return ""
 
     def getExportFilename(self, settingsWidget, varName=None, filter=None):
 


### PR DESCRIPTION
This took me a while to figure out a week ago when I tried manuskript for the first time, I didn't understand why the exporter had stopped working until I opened a console to check the log and see the re.error exception.
This fixes that so if a regexp is invalid, it will show a warning window and cancel the export instead of crashing.