### PR TITLE
Fix crash when right clicking a word in editor and enchant is not installed

### DIFF
--- a/manuskript/ui/views/textEditView.py
+++ b/manuskript/ui/views/textEditView.py
@@ -470,7 +470,7 @@ class textEditView(QTextEdit):
 
         # Check if the selected word is misspelled and offer spelling
         # suggestions if it is.
-        if cursor.hasSelection():
+        if self._dict and cursor.hasSelection():
             text = str(cursor.selectedText())
             valid = self._dict.check(text)
             selectedWord = cursor.selectedText()


### PR DESCRIPTION
Error was : 
```
  File "v:\Projects\book\manuskript-git\bin\..\manuskript\ui\views\textEditView.py", line 475, in createStandardContextMenu
    valid = self._dict.check(text)
AttributeError: 'NoneType' object has no attribute 'check'
```

Disabling the entire spellcheck section by checking if self._dict is None does the trick.