### PR TITLE
2nd try to fix macOS X blank screen when leaving fullscreen editor mode

### DIFF
--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -123,6 +123,7 @@ class fullScreenEditor(QWidget):
     def __del__(self):
         # print("Leaving fullScreenEditor via Destructor event", flush=True)
         self.showNormal()
+        self.close()
 
     def setLocked(self, val):
         self._locked = val


### PR DESCRIPTION
See issue #24.

The first attempt to fix this problem was with commit:

    Try to fix macOS X blank screen when leaving editor fullscreen mode
    1ae0a77464b094ec3c01462e5003dcb741e502de

This attempt adds a `self.close` call for the **Close** button exit similar to how the **ESC** key press exit works.