### PR TITLE
Fix fullscreen editor's myScrollBar delayed destruction causing a crash

### DIFF
--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -312,10 +312,13 @@ class myScrollBar(QScrollBar):
         self.timer = QTimer()
         self.timer.setInterval(500)
         self.timer.setSingleShot(True)
-        self.timer.timeout.connect(lambda: self.parent().hideWidget(self))
+        self.timer.timeout.connect(self.hide)
         self.valueChanged.connect(lambda v: self.timer.start())
         self.valueChanged.connect(lambda: self.parent().showWidget(self))
         self.rangeChanged.connect(self.rangeHasChanged)
+
+    def hide(self):
+        self.parent().hideWidget(self)
 
     def setColor(self, color):
         self._color = color


### PR DESCRIPTION
This can lead to a crash if a timer was started right before deletion, so that when
the timer is launched, the self.parent() crashes.

```
Traceback (most recent call last):
  File "v:\Projects\book\manuskript-git\bin\..\manuskript\ui\editors\fullScreenEditor.py", line 314, in <lambda>
    self.timer.timeout.connect(lambda: self.parent().hideWidget(self))
RuntimeError: Wrapped C/C++ object of type myScrollbar has been deleted
```

I've had this error happen to me multiple times after pressing F11 once as soon as I start the app, but I've been unable to reproduce it after adding debug messages (and also after removing them), so it looks like a heisenbug, but this should fix the problem, even though I can't test that it works, it seems logical. I'm also unsure on why a scrollbar would get destroyed after I enter fullscreen mode once without exiting it.