### PR TITLE
Set editor theme stylesheet to QTextEdit only.

### DIFF
--- a/manuskript/ui/editors/themes.py
+++ b/manuskript/ui/editors/themes.py
@@ -249,12 +249,14 @@ def setThemeEditorDatas(editor, themeDatas, pixmap, screenRect):
     # editor.setFont(f)
 
     editor.setStyleSheet("""
-        background: transparent;
-        color: {foreground};
-        font-family: {ff};
-        font-size: {fs};
-        selection-color: {sc};
-        selection-background-color: {sbc};
+        QTextEdit {{
+            background: transparent;
+            color: {foreground};
+            font-family: {ff};
+            font-size: {fs};
+            selection-color: {sc};
+            selection-background-color: {sbc};
+        }}
         """.format(
             foreground=themeDatas["Text/Color"],
             ff=f.family(),


### PR DESCRIPTION
This prevents any child widget from inheriting the same stylesheet,
more specifically, the context menu of the full screen editor will now
appear normal instead of being black text on black background, which made
it unreadable.

Fixes #440 

**note**: I have tested this and full screen mode looks good, as well as the side panels and the context menu, but I don't know if there are any other potential child widget other than QMenu which would actually need to inherit that theme data.
I have also tried to make the background same as the theme data instead of 'transparent', but it looks bad in the menu and there is no difference in text color between selectable and non selectable menu items (such as copy/paste/undo/redo), so I preferred to opt for a standard menu instead.
