### PR TITLE
Do not default spellcheck to True for new editor views

### DIFF
--- a/manuskript/ui/editors/editorWidget.py
+++ b/manuskript/ui/editors/editorWidget.py
@@ -54,7 +54,7 @@ class editorWidget(QWidget, Ui_editorWidget_ui):
         self.dictChanged.connect(self.txtRedacText.setDict, AUC)
         self.txtRedacText.setHighlighting(True)
         self.currentDict = ""
-        self.spellcheck = True
+        self.spellcheck = settings.spellcheck
         self.folderView = "cork"
         self.mw = mainWindow()
         self._tabWidget = None  # set by mainEditor on creation

--- a/manuskript/ui/views/MDEditView.py
+++ b/manuskript/ui/views/MDEditView.py
@@ -23,7 +23,7 @@ class MDEditView(textEditView):
     imageRegex = QRegExp("!\\[([^\n]*)\\]\\(([^\n]+)\\)")
     automaticLinkRegex = QRegExp("(<([a-zA-Z]+\\:[^\n]+)>)|(<([^\n]+@[^\n]+)>)")
 
-    def __init__(self, parent=None, index=None, html=None, spellcheck=True,
+    def __init__(self, parent=None, index=None, html=None, spellcheck=None,
                  highlighting=False, dict="", autoResize=False):
         textEditView.__init__(self, parent, index, html, spellcheck,
                               highlighting=True, dict=dict,

--- a/manuskript/ui/views/textEditView.py
+++ b/manuskript/ui/views/textEditView.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 class textEditView(QTextEdit):
-    def __init__(self, parent=None, index=None, html=None, spellcheck=True,
+    def __init__(self, parent=None, index=None, html=None, spellcheck=None,
                  highlighting=False, dict="", autoResize=False):
         QTextEdit.__init__(self, parent)
         self._column = Outline.text
@@ -38,6 +38,9 @@ class textEditView(QTextEdit):
         self._fromTheme = False
         self._themeData = None
         self._highlighterClass = BasicHighlighter
+
+        if spellcheck is None:
+            spellcheck = settings.spellcheck
 
         self.spellcheck = spellcheck
         self.currentDict = dict if dict else settings.dict


### PR DESCRIPTION
default spellcheck to the settings value instead. Otherwise any new editor tab
will have spellcheck enabled regardless of setting.

Fixes #474