### PR TITLE
Refactor spellchecker code and add other spellcheck library support

### DIFF
--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -12,7 +12,6 @@ from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import qApp, QTextEdit
 
 from manuskript.enums import Outline
-from manuskript.functions.spellchecker import Spellchecker
 
 # Used to detect multiple connections
 AUC = Qt.AutoConnection | Qt.UniqueConnection
@@ -398,3 +397,6 @@ def inspect():
             s.lineno,
             s.function))
         print("   " + "".join(s.code_context))
+
+# Spellchecker loads writablePath from this file, so we need to load it after they get defined
+from manuskript.functions.spellchecker import Spellchecker

--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -12,6 +12,7 @@ from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import qApp, QTextEdit
 
 from manuskript.enums import Outline
+from manuskript.functions.spellchecker import Spellchecker
 
 # Used to detect multiple connections
 AUC = Qt.AutoConnection | Qt.UniqueConnection

--- a/manuskript/functions/spellchecker.py
+++ b/manuskript/functions/spellchecker.py
@@ -1,0 +1,139 @@
+
+from PyQt5.QtCore import QLocale
+
+try:
+    import enchant
+except ImportError:
+    enchant = None
+
+class Spellchecker:
+    dictionaries = {}
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def isInstalled():
+        return enchant is not None
+
+    @staticmethod
+    def availableDictionaries():
+        return EnchantDictionary.availableDictionaries()
+
+    @staticmethod
+    def getDefaultDictionary():
+        return EnchantDictionary.getDefaultDictionary()
+
+    @staticmethod
+    def getLibraryURL():
+        return EnchantDictionary.getLibraryURL()
+
+    @staticmethod
+    def getDictionary(dictionary):
+        if not dictionary:
+            dictionary = Spellchecker.getDefaultDictionary()
+        try:
+            d = Spellchecker.dictionaries.get(dictionary, None)
+            if d is None:
+                d = EnchantDictionary(dictionary)
+                Spellchecker.dictionaries[d.name] = d
+            return d
+        except Exception as e:
+            return None
+
+class BasicDictionary:
+    def __init__(self, name):
+        pass
+
+    @property
+    def name(self):
+        raise NotImplemented
+
+    @staticmethod
+    def getLibraryName():
+        raise NotImplemented
+
+    @staticmethod
+    def getLibraryURL():
+        raise NotImplemented
+
+    @staticmethod
+    def getDefaultDictionary():
+        raise NotImplemented
+
+    @staticmethod
+    def availableDictionaries():
+        raise NotImplemented
+
+    def isMisspelled(self, word):
+        raise NotImplemented
+
+    def getSuggestions(self, word):
+        raise NotImplemented
+
+    def isCustomWord(self, word):
+        raise NotImplemented
+
+    def addWord(self, word):
+        raise NotImplemented
+
+    def removeWord(self, word):
+        raise NotImplemented
+
+class EnchantDictionary(BasicDictionary):
+
+    def __init__(self, name):
+        self._lang = name
+        if not (self._lang and enchant.dict_exists(self._lang)):
+            self._lang = self.getDefaultDictionary()
+
+        self._dict = enchant.Dict(self._lang)
+
+    @property
+    def name(self):
+        return self._lang
+
+    @staticmethod
+    def getLibraryName():
+        return "pyEnchant"
+
+    @staticmethod
+    def getLibraryURL():
+        return "https://pypi.org/project/pyenchant/"
+
+    @staticmethod
+    def availableDictionaries():
+        if enchant:
+            return list(map(lambda i: str(i[0]), enchant.list_dicts()))
+        return []
+
+    @staticmethod
+    def getDefaultDictionary():
+        if not enchant:
+            return None
+
+        default_locale = enchant.get_default_language()
+        if default_locale and not enchant.dict_exists(default_locale):
+            default_locale = None
+
+        if default_locale is None:
+            default_locale = QLocale.system().name()
+        if default_locale is None:
+            default_locale = self.availableDictionaries()[0]
+
+        return default_locale
+
+    def isMisspelled(self, word):
+        return not self._dict.check(word)
+
+    def getSuggestions(self, word):
+        return self._dict.suggest(word)
+
+    def isCustomWord(self, word):
+        return self._dict.is_added(word)
+
+    def addWord(self, word):
+        self._dict.add(word)
+
+    def removeWord(self, word):
+        self._dict.remove(word)

--- a/manuskript/functions/spellchecker.py
+++ b/manuskript/functions/spellchecker.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# --!-- coding: utf8 --!--
 
 import os, gzip, json, glob
 from PyQt5.QtCore import QLocale

--- a/manuskript/functions/spellchecker.py
+++ b/manuskript/functions/spellchecker.py
@@ -1,45 +1,111 @@
 
+import os, gzip, json
 from PyQt5.QtCore import QLocale
+from collections import OrderedDict
+from manuskript.functions import writablePath
 
 try:
     import enchant
 except ImportError:
     enchant = None
 
+try:
+    import spellchecker as pyspellchecker
+except ImportError:
+    pyspellchecker = None
+
+
 class Spellchecker:
     dictionaries = {}
+    # In order of priority
+    implementations = []
 
     def __init__(self):
         pass
 
     @staticmethod
     def isInstalled():
-        return enchant is not None
+        for impl in Spellchecker.implementations:
+            if impl.isInstalled():
+                return True
+        return False
+
+    @staticmethod
+    def supportedLibraries():
+        libs = []
+        for impl in Spellchecker.implementations:
+            libs.append(impl.getLibraryName())
+        return libs
+
+    @staticmethod
+    def availableLibraries():
+        ret = []
+        for impl in Spellchecker.implementations:
+            if impl.isInstalled():
+                ret.append(impl.getLibraryName())
+        return ret
 
     @staticmethod
     def availableDictionaries():
-        return EnchantDictionary.availableDictionaries()
+        dictionaries = OrderedDict()
+        for impl in Spellchecker.implementations:
+            dictionaries[impl.getLibraryName()] = impl.availableDictionaries()
+        return dictionaries
+
+    @staticmethod
+    def normalizeDictName(lib, dictionary):
+        return "{}:{}".format(lib, dictionary)
 
     @staticmethod
     def getDefaultDictionary():
-        return EnchantDictionary.getDefaultDictionary()
+        for impl in Spellchecker.implementations:
+            default = impl.getDefaultDictionary()
+            if default:
+                return Spellchecker.normalizeDictName(impl.getLibraryName(), default)
+        return None
 
     @staticmethod
-    def getLibraryURL():
-        return EnchantDictionary.getLibraryURL()
+    def getLibraryURL(lib=None):
+        urls = {}
+        for impl in Spellchecker.implementations:
+            urls[impl.getLibraryName()] = impl.getLibraryURL()
+        if lib:
+            return urls.get(lib, None)
+        return urls
+
+    
+    @staticmethod
+    def getResourcesPath(library):
+        path = os.path.join(writablePath(), "resources", "dictionaries", library)
+        if not os.path.exists(path):
+            os.makedirs(path)
+        return path
 
     @staticmethod
     def getDictionary(dictionary):
         if not dictionary:
             dictionary = Spellchecker.getDefaultDictionary()
+        if not dictionary:
+            return None
+
+        values = dictionary.split(":", 1)
+        if len(values) == 1:
+            (lib, name) = (Spellchecker.implementations[0].getLibraryName(), dictionary)
+            dictionary = Spellchecker.normalizeDictName(lib, name)
+        else:
+            (lib, name) = values
         try:
             d = Spellchecker.dictionaries.get(dictionary, None)
             if d is None:
-                d = EnchantDictionary(dictionary)
-                Spellchecker.dictionaries[d.name] = d
+                for impl in Spellchecker.implementations:
+                    if lib == impl.getLibraryName():
+                        d = impl(name)
+                        Spellchecker.dictionaries[dictionary] = d
+                        break
             return d
         except Exception as e:
-            return None
+            pass
+        return None
 
 class BasicDictionary:
     def __init__(self, name):
@@ -55,6 +121,10 @@ class BasicDictionary:
 
     @staticmethod
     def getLibraryURL():
+        raise NotImplemented
+
+    @staticmethod
+    def isInstalled():
         raise NotImplemented
 
     @staticmethod
@@ -95,21 +165,25 @@ class EnchantDictionary(BasicDictionary):
 
     @staticmethod
     def getLibraryName():
-        return "pyEnchant"
+        return "PyEnchant"
 
     @staticmethod
     def getLibraryURL():
         return "https://pypi.org/project/pyenchant/"
 
     @staticmethod
+    def isInstalled():
+        return enchant is not None
+
+    @staticmethod
     def availableDictionaries():
-        if enchant:
+        if EnchantDictionary.isInstalled():
             return list(map(lambda i: str(i[0]), enchant.list_dicts()))
         return []
 
     @staticmethod
     def getDefaultDictionary():
-        if not enchant:
+        if not EnchantDictionary.isInstalled():
             return None
 
         default_locale = enchant.get_default_language()
@@ -137,3 +211,90 @@ class EnchantDictionary(BasicDictionary):
 
     def removeWord(self, word):
         self._dict.remove(word)
+Spellchecker.implementations.append(EnchantDictionary)
+
+
+class PySpellcheckerDictionary(BasicDictionary):
+
+    def __init__(self, name):
+        self._lang = name
+        if not self._lang:
+            self._lang = self.getDefaultDictionary()
+
+        self._dict = pyspellchecker.SpellChecker(self._lang)
+        self._customDict = None
+        customPath = self.getCustomDictionaryPath()
+        try:
+            self._customDict = pyspellchecker.SpellChecker(local_dictionary=customPath)
+            self._dict.word_frequency.load_dictionary(customPath)
+        except:
+            # If error loading the file, overwrite with empty dictionary
+            with gzip.open(customPath, "wt") as f:
+                f.write(json.dumps({}))
+                
+        self._customDict = pyspellchecker.SpellChecker(local_dictionary=customPath)
+        self._dict.word_frequency.load_dictionary(customPath)
+
+    def getCustomDictionaryPath(self):
+        return os.path.join(Spellchecker.getResourcesPath(self.getLibraryName()), "{}.json.gz".format(self._lang))
+
+    @property
+    def name(self):
+        return self._lang
+
+    @staticmethod
+    def getLibraryName():
+        return "pyspellchecker"
+
+    @staticmethod
+    def getLibraryURL():
+        return "https://pyspellchecker.readthedocs.io/en/latest/"
+
+    @staticmethod
+    def isInstalled():
+        return pyspellchecker is not None
+
+    @staticmethod
+    def availableDictionaries():
+        if PySpellcheckerDictionary.isInstalled():
+            # TODO: If pyspellchecker eventually adds a way to get this list
+            # programmatically or if the list changes, we need to update it here
+            return ["de", "en", "es", "fr", "pt"]
+        return []
+
+    @staticmethod
+    def getDefaultDictionary():
+        if not PySpellcheckerDictionary.isInstalled():
+            return None
+
+        default_locale = QLocale.system().name()
+        if default_locale:
+            default_locale = default_locale[0:2]
+        if default_locale is None:
+            default_locale = "en"
+
+        return default_locale
+
+    def isMisspelled(self, word):
+        return len(self._dict.unknown([word])) > 0
+
+    def getSuggestions(self, word):
+        candidates = self._dict.candidates(word)
+        if word in candidates:
+            candidates.remove(word)
+        return candidates
+
+    def isCustomWord(self, word):
+        return len(self._customDict.known([word])) > 0
+
+    def addWord(self, word):
+        self._dict.word_frequency.add(word)
+        self._customDict.word_frequency.add(word)
+        self._customDict.export(self.getCustomDictionaryPath(), gzipped=True)
+
+    def removeWord(self, word):
+        self._dict.word_frequency.remove(word)
+        self._customDict.word_frequency.remove(word)
+        self._customDict.export(self.getCustomDictionaryPath(), gzipped=True)
+
+Spellchecker.implementations.append(PySpellcheckerDictionary)

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -1255,8 +1255,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         else:
             # No Spell check support
             self.actSpellcheck.setVisible(False)
-            for lib in Spellchecker.supportedLibraries():
-                a = QAction(self.tr("Install {} to use spellcheck").format(lib), self)
+            for lib, requirement in Spellchecker.supportedLibraries().items():
+                a = QAction(self.tr("Install {}{} to use spellcheck").format(lib, requirement or ""), self)
                 a.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxWarning))
                 # Need to bound the lib argument otherwise the lambda uses the same lib value across all calls
                 def gen_slot_cb(l):
@@ -1275,11 +1275,12 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             return
 
         self.menuDict.clear()
-        for lib, dicts in Spellchecker.availableDictionaries().items():
-            if len(dicts) > 1:
+        dictionaries = Spellchecker.availableDictionaries()
+        for lib, dicts in dictionaries.items():
+            if len(dicts) > 0:
                 a = QAction(lib, self)
             else:
-                a = QAction(self.tr("{} is not installed").format(lib), self)
+                a = QAction(self.tr("{} has no installed dictionaries").format(lib), self)
             a.setEnabled(False)
             self.menuDict.addAction(a)
             for i in dicts:
@@ -1294,6 +1295,13 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 self.menuDictGroup.addAction(a)
                 self.menuDict.addAction(a)
             self.menuDict.addSeparator()
+
+        for lib, requirement in Spellchecker.supportedLibraries().items():
+            if lib not in dictionaries:
+                a = QAction(self.tr("{}{} is not installed").format(lib, requirement or ""), self)
+                a.setEnabled(False)
+                self.menuDict.addAction(a)
+                self.menuDict.addSeparator()
 
     def setDictionary(self):
         if not Spellchecker.isInstalled():

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -34,15 +34,10 @@ from manuskript.ui.statusLabel import statusLabel
 
 # Spellcheck support
 from manuskript.ui.views.textEditView import textEditView
-
-try:
-    import enchant
-except ImportError:
-    enchant = None
-
+from manuskript.functions import Spellchecker
 
 class MainWindow(QMainWindow, Ui_MainWindow):
-    dictChanged = pyqtSignal(str)
+    # dictChanged = pyqtSignal(str)
 
     # Tab indexes
     TabInfos = 0
@@ -1246,16 +1241,16 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.actShowHelp.setChecked(False)
 
         # Spellcheck
-        if enchant:
+        if Spellchecker.isInstalled():
             self.menuDict = QMenu(self.tr("Dictionary"))
             self.menuDictGroup = QActionGroup(self)
             self.updateMenuDict()
             self.menuTools.addMenu(self.menuDict)
 
             self.actSpellcheck.toggled.connect(self.toggleSpellcheck, F.AUC)
-            self.dictChanged.connect(self.mainEditor.setDict, F.AUC)
-            self.dictChanged.connect(self.redacMetadata.setDict, F.AUC)
-            self.dictChanged.connect(self.outlineItemEditor.setDict, F.AUC)
+            # self.dictChanged.connect(self.mainEditor.setDict, F.AUC)
+            # self.dictChanged.connect(self.redacMetadata.setDict, F.AUC)
+            # self.dictChanged.connect(self.outlineItemEditor.setDict, F.AUC)
 
         else:
             # No Spell check support
@@ -1271,23 +1266,23 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def updateMenuDict(self):
 
-        if not enchant:
+        if not Spellchecker.isInstalled():
             return
 
         self.menuDict.clear()
-        for i in enchant.list_dicts():
-            a = QAction(str(i[0]), self)
+        for i in Spellchecker.availableDictionaries():
+            a = QAction(i, self)
             a.setCheckable(True)
             if settings.dict is None:
-                settings.dict = enchant.get_default_language()
-            if str(i[0]) == settings.dict:
+                settings.dict = Spellchecker.getDefaultDictionary()
+            if i == settings.dict:
                 a.setChecked(True)
             a.triggered.connect(self.setDictionary, F.AUC)
             self.menuDictGroup.addAction(a)
             self.menuDict.addAction(a)
 
     def setDictionary(self):
-        if not enchant:
+        if not Spellchecker.isInstalled():
             return
 
         for i in self.menuDictGroup.actions():
@@ -1301,7 +1296,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                     w.setDict(settings.dict)
 
     def openPyEnchantWebPage(self):
-        F.openURL("http://pythonhosted.org/pyenchant/")
+        F.openURL(Spellchecker.getLibraryURL())
 
     def toggleSpellcheck(self, val):
         settings.spellcheck = val

--- a/manuskript/settingsWindow.py
+++ b/manuskript/settingsWindow.py
@@ -26,11 +26,6 @@ from manuskript.ui.views.textEditView import textEditView
 from manuskript.ui.welcome import welcome
 from manuskript.ui import style as S
 
-try:
-    import enchant
-except ImportError:
-    enchant = None
-
 
 class settingsWindow(QWidget, Ui_Settings):
     def __init__(self, mainWindow):

--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -16,11 +16,7 @@ from manuskript.ui.editors.locker import locker
 from manuskript.ui.editors.themes import findThemePath, generateTheme, setThemeEditorDatas
 from manuskript.ui.editors.themes import loadThemeDatas
 from manuskript.ui.views.MDEditView import MDEditView
-
-try:
-    import enchant
-except ImportError:
-    enchant = None
+from manuskript.functions import Spellchecker
 
 
 class fullScreenEditor(QWidget):
@@ -53,7 +49,7 @@ class fullScreenEditor(QWidget):
         # self.topPanel.layout().addStretch(1)
 
         # Spell checking
-        if enchant:
+        if Spellchecker.isInstalled():
             self.btnSpellCheck = QPushButton(self)
             self.btnSpellCheck.setFlat(True)
             self.btnSpellCheck.setIcon(QIcon.fromTheme("tools-check-spelling"))

--- a/manuskript/ui/highlighters/basicHighlighter.py
+++ b/manuskript/ui/highlighters/basicHighlighter.py
@@ -152,7 +152,7 @@ class BasicHighlighter(QSyntaxHighlighter):
         if hasattr(self.editor, "spellcheck") and self.editor.spellcheck:
             for word_object in re.finditer(WORDS, textedText):
                 if (self.editor._dict
-                        and not self.editor._dict.check(word_object.group(1))):
+                        and self.editor._dict.isMisspelled(word_object.group(1))):
                     format = self.format(word_object.start(1))
                     format.setUnderlineColor(self._misspelledColor)
                     # SpellCheckUnderline fails with some fonts

--- a/manuskript/ui/views/MDEditCompleter.py
+++ b/manuskript/ui/views/MDEditCompleter.py
@@ -10,11 +10,6 @@ from manuskript.ui.editors.completer import completer
 from manuskript.ui.views.MDEditView import MDEditView
 from manuskript.models import references as Ref
 
-try:
-    import enchant
-except ImportError:
-    enchant = None
-
 
 class MDEditCompleter(MDEditView):
     def __init__(self, parent=None, index=None, html=None, spellcheck=True, highlighting=False, dict="",

--- a/manuskript/ui/views/textEditView.py
+++ b/manuskript/ui/views/textEditView.py
@@ -464,16 +464,16 @@ class textEditView(QTextEdit):
                     action = self.SpellAction(word, spell_menu)
                     action.correct.connect(self.correctWord)
                     spell_menu.addAction(action)
+                popup_menu.insertSeparator(popup_menu.actions()[0])
+                # Adds: add to dictionary
+                addAction = QAction(self.tr("&Add to dictionary"), popup_menu)
+                addAction.setIcon(QIcon.fromTheme("list-add"))
+                addAction.triggered.connect(self.addWordToDict)
+                addAction.setData(selectedWord)
+                popup_menu.insertAction(popup_menu.actions()[0], addAction)
                 # Only add the spelling suggests to the menu if there are
                 # suggestions.
                 if len(spell_menu.actions()) != 0:
-                    popup_menu.insertSeparator(popup_menu.actions()[0])
-                    # Adds: add to dictionary
-                    addAction = QAction(self.tr("&Add to dictionary"), popup_menu)
-                    addAction.setIcon(QIcon.fromTheme("list-add"))
-                    addAction.triggered.connect(self.addWordToDict)
-                    addAction.setData(selectedWord)
-                    popup_menu.insertAction(popup_menu.actions()[0], addAction)
                     # Adds: suggestions
                     popup_menu.insertMenu(popup_menu.actions()[0], spell_menu)
                     # popup_menu.insertSeparator(popup_menu.actions()[0])


### PR DESCRIPTION
This is a rather big change, but should be easy to review one commit at a time. It will add an abstraction for the spellchecker then add support for pyspellchecker.
Only 'bug'/issue I have is if I run 32 bit version and select a PyEnchant dictionary, then run the 64 bit version, then spellchecking doesn't work because my settings have stored "PyEnchant:en_US" as the chosen dictionary, so I'd have to reselect the pyspellchecker dictionary for it to work again.. this could happen to a user and they'd be lost as to why it's not working.
Another issue that would need to be discussed is whether we should have the custom dictionary entries stored in the project file or not. It makes sense if you add to dictionary weird character names or fantasy world names/concepts, but if you're just fixing the dictionary to add words you often use across projects, it could be annoying. Anyway, needs to be discussed.