### PR TITLE
Fix corkView background image on Windows

### DIFF
--- a/manuskript/ui/views/corkView.py
+++ b/manuskript/ui/views/corkView.py
@@ -36,7 +36,7 @@ class corkView(QListView, dndView, outlineBasics):
             background-attachment: fixed;
             }}""".format(
                 color=settings.corkBackground["color"],
-                url=img
+                url=img.replace("\\", "/")
         ))
 
     def dragMoveEvent(self, event):


### PR DESCRIPTION
Windows path to the image has '\\' path separator instead of '/' which makes
the stylesheet fail. Background images don't appear and console gets spammed with :
Could not parse stylesheet of object corkView(0x27248eb6900, name = "corkView")

I grew tired of that message on the console and hadn't realized the corkview was supposed to have a background image. It looks much nicer now.

Note: I have not tested if this causes issues in case the path is supposed to have some escaped characters in it. I don't know if we're supposed to urlencode the path or something like that, but for now, this works for me.