### PR TITLE
Add snap build and package

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,6 +36,9 @@ i18n: $(QMs)
 pyinstaller:
 	python3 /usr/local/bin/pyinstaller manuskript.spec
 
+snap:
+	snapcraft snap
+
 stats:
 	python3 libs/gh-release-stats.py olivierkes manuskript -d
 

--- a/snap/gui/manuskript.desktop
+++ b/snap/gui/manuskript.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Manuskript
+Comment=An open source tool for writers
+Keywords=manuskript;office;write;edit;novel;text;msk
+Exec=manuskript
+Terminal=false
+Type=Application
+Icon=/snap/manuskript/current/icons/Manuskript/manuskript.svg
+Categories=Office;WordProcessor;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,97 @@
+name: manuskript
+version: overwritten
+version-script: grep -E  "__version__.*\".*\"" "manuskript/version.py" | cut -d\" -f2
+summary: Manuskript is an open-source tool for writers.
+description: |
+  Manuskript provides a rich environment to help writers create their first draft and then further refine and edit their masterpiece.
+  With Manuskript you can:
+    Grow your premise from one sentence, to a paragraph, to a full summary
+    Create characters
+    Conceive plots
+    Construct outlines (Outline mode and/or Index cards)
+    Write with focus (Distraction free mode)
+    Build worlds
+    Track items
+    Edit and re-organize chapters and scenes
+    View Story line
+    Compose with fiction or non-fiction templates and writing modes
+    Export to HTML, ePub, OpenDocument, DocX, PDF, and more
+    Additionally Manuskript can help in many more ways with a spell checker, markdown highlighter, frequency analyzer, and automatic save in open and plain text file format.
+grade: stable
+confinement: strict
+base: core18
+icon: icons/Manuskript/manuskript.svg
+
+apps:
+  manuskript:
+    command: desktop-launch $SNAP/bin/manuskript
+    plugs:
+    - desktop
+    - desktop-legacy
+    - unity7
+    - wayland
+    - x11
+    - opengl
+    - home
+
+parts:
+  desktop-qt5:
+    build-packages:
+    - build-essential
+    - qtbase5-dev
+    - dpkg-dev
+    make-parameters:
+    - FLAVOR=qt5
+    plugin: make
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: qt
+    stage-packages:
+    - libxkbcommon0
+    - ttf-ubuntu-font-family
+    - dmz-cursor-theme
+    - light-themes
+    - adwaita-icon-theme
+    - gnome-themes-standard
+    - shared-mime-info
+    - libqt5gui5
+    - libgdk-pixbuf2.0-0
+    - libqt5svg5
+    - try:
+      - appmenu-qt5
+    - locales-all
+    - xdg-user-dirs
+    - fcitx-frontend-qt5
+
+  manuskript:
+    after: [desktop-qt5]
+    plugin: dump
+    source: https://github.com/olivierkes/manuskript.git
+    source-type: git
+    build-packages:
+      - python3
+      - python3-pyqt5
+      - python3-pyqt5.qtwebkit
+      - libqt5svg5
+      - python3-lxml
+      - zlib1g
+      - python3-enchant
+      - python3-markdown
+      - pandoc
+      - texlive-latex-recommended
+      - texlive-fonts-recommended
+      - texlive-luatex
+    stage-packages:
+      - python3
+      - python3-pyqt5
+      - python3-pyqt5.qtwebkit
+      - libqt5svg5
+      - python3-lxml
+      - zlib1g
+      - libc-bin
+      - locales
+      - python3-enchant
+      - python3-markdown
+      - pandoc
+      - texlive-latex-recommended
+      - texlive-fonts-recommended
+      - texlive-luatex


### PR DESCRIPTION
Hi,

Referencing https://github.com/olivierkes/manuskript/issues/71 I have created a snap build for the manuskript project. This should work on any platform supported by snapd.

This can be built by installing [snapcraft](https://docs.snapcraft.io/snapcraft-overview/8940) and running `make snap`, or `snapcraft` in the project directory.

I haven't registered the name in the store as I didn't want to appear to be namesquatting or similar, though I'm happy to do that, fill in the metadata and transfer it to you if you'd prefer.

This can be released to the store following the [release instructions](https://docs.snapcraft.io/releasing-your-app/6795)

I'm happy to answer any questions and help if I can.