### PR TITLE
Fix background of popup menus that were transparent (black)

### DIFF
--- a/manuskript/ui/views/outlineBasics.py
+++ b/manuskript/ui/views/outlineBasics.py
@@ -203,7 +203,7 @@ class outlineBasics(QAbstractItemView):
             txt = QLineEdit()
             txt.textChanged.connect(self.filterLstIcons)
             txt.setPlaceholderText("Filter icons")
-            txt.setStyleSheet("background: transparent; border: none;")
+            txt.setStyleSheet("QLineEdit { background: transparent; border: none; }")
             act = QWidgetAction(self.menuCustomIcons)
             act.setDefaultWidget(txt)
             self.menuCustomIcons.addAction(act)

--- a/manuskript/ui/views/propertiesView_ui.py
+++ b/manuskript/ui/views/propertiesView_ui.py
@@ -20,7 +20,7 @@ class Ui_propertiesView(object):
         font.setBold(True)
         font.setWeight(75)
         self.txtTitle.setFont(font)
-        self.txtTitle.setStyleSheet("background:transparent;")
+        self.txtTitle.setStyleSheet("QLineEdit { background:transparent; }")
         self.txtTitle.setFrame(False)
         self.txtTitle.setObjectName("txtTitle")
         self.verticalLayout.addWidget(self.txtTitle)

--- a/manuskript/ui/views/propertiesView_ui.ui
+++ b/manuskript/ui/views/propertiesView_ui.ui
@@ -35,7 +35,7 @@
       </font>
      </property>
      <property name="styleSheet">
-      <string notr="true">background:transparent;</string>
+      <string notr="true">QLineEdit { background:transparent; }</string>
      </property>
      <property name="frame">
       <bool>false</bool>


### PR DESCRIPTION
In the properties view, the context menu on the title line would be black
making its content unreadable. Same in the filter line of the "Set Custom icon"
window on the outline's context menu.

Note: This is similar to #504, not sure if you'd prefer the commits to be squished and sent as a single PR.

The propertiesView_ui.py file, I modified manually instead of auto-generating it, I consider the change to be small enough that it's not needed and it's risk free, besides I don't have pyuic installed and I don't know if we'd have the same version and whether the result would be exactly the same and I wanted to limit the amount of changes the diff would have.

Note that in outlineBasics on line 223, there's a `QListWidget` that also uses a similar stylesheet : 
``` self.lstIcons.setStyleSheet("background: transparent; background: none;")```
I don't know if the 'background:none' is overriding the 'background:transparent' and I don't know if a transparent background is supposed to be there for children since `QListWidgetItem`s might need it, so I just left it as is. Either way, there is no context menu on that widget, so I think it's fine, but you might know better so I thought best to give you the FYI.