### PR TITLE
Fix crash when right-clicking twice on fullscreen panel

### DIFF
--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -359,6 +359,7 @@ class myPanel(QWidget):
         self.show()
         self.setAttribute(Qt.WA_TranslucentBackground)
         self._autoHide = True
+        self._m = None
 
         if not vertical:
             self.setLayout(QHBoxLayout())
@@ -379,6 +380,8 @@ class myPanel(QWidget):
 
     def mouseReleaseEvent(self, event):
         if event.button() == Qt.RightButton:
+            if self._m:
+                self._m.deleteLater()
             m = QMenu()
             a = QAction(self.tr("Auto-hide"), m)
             a.setCheckable(True)


### PR DESCRIPTION
If you right click once on the fullscreen panel and the context menu pop up
then you right click again somewhere else on the panel *while the previous
context menu is still visible* then it will cause a crash with :
"Windows fatal exception: access violation"
It seems to be caused by a crash in the QT event loop, trying to delete the
existing QMenu within an event handler.