### PR TITLE
Ensure text file open methods use utf-8 encoding

### DIFF
--- a/manuskript/importer/folderImporter.py
+++ b/manuskript/importer/folderImporter.py
@@ -44,7 +44,7 @@ class folderImporter(abstractImporter):
                 fName, fExt = os.path.splitext(f)
                 if fExt.lower() in ext:
                     try:
-                        with open(os.path.join(dirpath, f), "r") as fr:
+                        with open(os.path.join(dirpath, f), "r", encoding="utf-8") as fr:
                             content = fr.read()
                         child = outlineItem(title=fName, _type="md", parent=item)
                         child._data[Outline.text] = content

--- a/manuskript/loadSave.py
+++ b/manuskript/loadSave.py
@@ -54,7 +54,7 @@ def loadProject(project):
 
     # Not a zip
     else:
-        with open(project, "r") as f:
+        with open(project, "r", encoding="utf-8") as f:
             version = int(f.read())
 
     print("Loading:", project)

--- a/manuskript/ui/exporters/manuskript/plainTextSettings.py
+++ b/manuskript/ui/exporters/manuskript/plainTextSettings.py
@@ -128,7 +128,7 @@ class exporterSettings(QWidget, Ui_exporterSettings):
     def loadSettings(self):
         filename = self.getSettingsPath()
         if os.path.exists(filename):
-            with open(filename) as f:
+            with open(filename, "r", encoding="utf-8") as f:
                 self.settings = json.load(f)
             self.updateFromSettings()
 
@@ -138,7 +138,7 @@ class exporterSettings(QWidget, Ui_exporterSettings):
 
     def writeSettings(self):
         self.getSettings()
-        with open(self.getSettingsPath(), 'w') as f:
+        with open(self.getSettingsPath(), 'w', encoding="utf-8") as f:
             # json.dumps(json.loads(json.dumps(allSettings)), indent=4, sort_keys=True)
             json.dump(self.settings, f, indent=4, sort_keys=True)
 


### PR DESCRIPTION
Several crashes were encountered opening files on operating systems
that do not default to UTF-8 encoding, such as Windows.  In each case
the project file appears to have become corrupted.  Because the only
reports to date have been on Windows, attempt to fix by specifying
utf-8 encoding for all text file open methods.

See issues #331, #470, and #502.