### PR TITLE
Directory entries in ZIP break loading code

### DIFF
--- a/manuskript/load_save/version_0.py
+++ b/manuskript/load_save/version_0.py
@@ -178,7 +178,10 @@ def loadFilesFromZip(zipname):
     zf = zipfile.ZipFile(zipname)
     files = {}
     for f in zf.namelist():
-        files[os.path.normpath(f)] = zf.read(f)
+        # Some archiving programs (e.g. 7-Zip) also store entries for the directories when
+        # creating an archive. We have no use for these entries; skip them entirely.
+        if f[-1:] != '/':
+            files[os.path.normpath(f)] = zf.read(f)
     return files
 
 


### PR DESCRIPTION
While tackling issue #529, I stumbled across the odd behaviour that re-compressing the archive with 7-Zip broke what should be a valid Manuskript project.

After investigation it turned out that the code that loads the texts sensibly expects there to only be files tracked in the files dictionary.

It is completely valid for a zip file to contain entries describing the contained directories. The logical fix is to simply avoid adding these directory entries to our files dictionary in the first place.

I have verified the fix against the project in issue #529 by having Manuskript manually save the unzipped version as a single file, and comparing the files it tries to load against a 7-Zip compressed project. They load exactly the same files with this patch applied.

Throwing it at my own project worked completely fine as well, so I am confident this is fixed and won't cause any data to be lost.