### PR TITLE
Fix color scheme of fullscreen editor

### DIFF
--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -147,8 +147,8 @@ class fullScreenEditor(QWidget):
         # Colors
         if self._themeDatas["Foreground/Color"] == self._themeDatas["Background/Color"] or \
                         self._themeDatas["Foreground/Opacity"] < 5:
-            self._bgcolor = QColor(self._themeDatas["Text/Color"])
-            self._fgcolor = QColor(self._themeDatas["Background/Color"])
+            self._fgcolor = QColor(self._themeDatas["Text/Color"])
+            self._bgcolor = QColor(self._themeDatas["Background/Color"])
         else:
             self._bgcolor = QColor(self._themeDatas["Foreground/Color"])
             self._bgcolor.setAlpha(self._themeDatas["Foreground/Opacity"] * 255 / 100)
@@ -202,7 +202,7 @@ class fullScreenEditor(QWidget):
         p.setBrush(QPalette.ButtonText, self._fgcolor)
         p.setBrush(QPalette.WindowText, self._fgcolor)
 
-        for panel in (self.bottomPanel, self.topPanel):
+        for panel in (self.bottomPanel, self.topPanel, self.leftPanel):
             for i in range(panel.layout().count()):
                 item = panel.layout().itemAt(i)
                 if item.widget():


### PR DESCRIPTION
Color scheme was inverted if foreground was transparent, bug and fix provided
by @tildagail [1] and the text on the left side panel was ignoring text color
settings, making it unreadable in dark themes, as reported by @worstje in #527

[1] https://github.com/olivierkes/manuskript/issues/527#issuecomment-469578130