### PR TITLE
Fixing outlineView.py to enable the outline to show full Title

### DIFF
--- a/manuskript/ui/views/outlineView.py
+++ b/manuskript/ui/views/outlineView.py
@@ -55,7 +55,7 @@ class outlineView(QTreeView, dndView, outlineBasics):
         # Hiding columns
         self.hideColumns()
 
-        self.header().setSectionResizeMode(Outline.title, QHeaderView.Stretch)
+        self.header().setSectionResizeMode(Outline.title, QHeaderView.ResizeToContents)
         self.header().setSectionResizeMode(Outline.POV, QHeaderView.ResizeToContents)
         self.header().setSectionResizeMode(Outline.status, QHeaderView.ResizeToContents)
         self.header().setSectionResizeMode(Outline.label, QHeaderView.ResizeToContents)


### PR DESCRIPTION
…the name of  Character is too long

If the name of a character in POV is a long one, it reduces the amount of space for Title. 

This modification (a simple change to the view) ensures that all columns fit it's content. This does enable a scroll-bar at the bottom of the screen for times when the full outline information is too long (QT default behaviour)