### PR TITLE
Fix occasional crashes when (re)moving items

### DIFF
--- a/manuskript/models/abstractItem.py
+++ b/manuskript/models/abstractItem.py
@@ -141,6 +141,9 @@ class abstractItem():
         @return: the removed abstractItem
         """
         r = self.childItems.pop(row)
+        # Disassociate the child from its parent and the model.
+        r._parent = None
+        r.setModel(None)
         return r
 
     def parent(self):

--- a/manuskript/models/outlineItem.py
+++ b/manuskript/models/outlineItem.py
@@ -178,13 +178,11 @@ class outlineItem(abstractItem):
 
     def removeChild(self, row):
         r = abstractItem.removeChild(self, row)
-        # Might be causing segfault when updateWordCount emits dataChanged
-        self.updateWordCount(emit=False)
+        self.updateWordCount()
         return r
 
-    def updateWordCount(self, emit=True):
-        """Update word count for item and parents.
-        If emit is False, no signal is emitted (sometimes cause segfault)"""
+    def updateWordCount(self):
+        """Update word count for item and parents."""
         if not self.isFolder():
             setGoal = F.toInt(self.data(self.enum.setGoal))
             goal = F.toInt(self.data(self.enum.goal))
@@ -219,12 +217,11 @@ class outlineItem(abstractItem):
             else:
                 self.setData(self.enum.goalPercentage, "")
 
-        if emit:
-            self.emitDataChanged([self.enum.goal, self.enum.setGoal,
-                                  self.enum.wordCount, self.enum.goalPercentage])
+        self.emitDataChanged([self.enum.goal, self.enum.setGoal,
+                              self.enum.wordCount, self.enum.goalPercentage])
 
         if self.parent():
-            self.parent().updateWordCount(emit)
+            self.parent().updateWordCount()
 
     def stats(self):
         wc = self.data(enums.Outline.wordCount)

--- a/manuskript/ui/views/outlineBasics.py
+++ b/manuskript/ui/views/outlineBasics.py
@@ -383,7 +383,7 @@ class outlineBasics(QAbstractItemView):
 
         parentItem.childItems.insert(index.row() + delta,
                                      parentItem.childItems.pop(index.row()))
-        parentItem.updateWordCount(emit=False)
+        parentItem.updateWordCount()
 
     def moveUp(self): self.move(-1)
     def moveDown(self): self.move(+1)


### PR DESCRIPTION
Describing all the rabbitholes that I and kakaroto have gone through
while debugging this one until dawn can frankly not do enough justice to
the crazy amount of rubberducking that went on while trying to fix this.

This bug would be triggered whenever you had a document open in the
editor and then moved an ancestor object downwards (visually) in the tree.
Or when you simply deleted the ancestor. Depending on the exact method
that caused the opened item to be removed from the internal model, the
exact nature of the bug would vary, which means this commit fixes a few
different bits of code that lead to what appears to be the same bug.

In order of appearance, the bugs that ruined our sleep were:

1) The editor widget was trying to handle the removed item at too late a
stage.

2) The editor widget tried to fix its view after a move by searching for
the new item with the same ID, but in the case of moving an object down
it came across its own old item, ruining the attempt.

3) The editor widget did not properly account for the hierarchical
nature of the model.

Upon fixing these the next day, it was revealed that:

4) The outlineItem.updateWordCount(emit=False) flag is broken. This
function would call setData() in several spots which would still cause
emits to bubble through the system despite emit=False, and we simply got
lucky that it stopped enough of them until now.

This last one was caused by a small mistake in the fixes for the first
three bugs, but it has led to a couple of extra changes to make any
future bug hunts slightly less arduous and frustrating:

a) When calling item.removeChild(c), it now resets the associated parent
and model to mirror item.insertChild(c). This has also led to an extra
check in model.parent() to check for its validity.

b) The outlineItem.updateWordCount(emit=) flag has been removed entirely
and it now emits away with reckless abandon. I have been unable to
reproduce the crashes the code warned about, so I consider this a code
quality fix to prevent mysterious future issues where things sometimes
do not properly update right.

Worthy of note is that the original code clearly showed the intention to
close tabs for items that were removed. Reworking the editor to support
closing a tab is unfortunately way out of scope, so this intention was
left in and the new fix was structured to make it trivial to implement
such a change when the time comes. An existing FIXME regarding unrelated
buggy editor behaviour was left in, too.

Many thanks to Kakaroto for burning the midnight oil with me to get to
the bottom of this. (I learned a lot that night!)

Issues #479 and #559 are fixed by this commit. And maybe some others,
too.