### PR TITLE
Fix dialog windows being created outside the desktop area

### DIFF
--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -1379,6 +1379,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def frequencyAnalyzer(self):
         self.fw = frequencyAnalyzer(self)
         self.fw.show()
+        self.centerChildWindow(self.fw)
 
     ###############################################################################
     # VIEW MENU

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -3,7 +3,7 @@
 import imp
 import os
 
-from PyQt5.QtCore import (pyqtSignal, QSignalMapper, QTimer, QSettings, Qt,
+from PyQt5.QtCore import (pyqtSignal, QSignalMapper, QTimer, QSettings, Qt, QPoint,
                           QRegExp, QUrl, QSize, QModelIndex)
 from PyQt5.QtGui import QStandardItemModel, QIcon, QColor
 from PyQt5.QtWidgets import QMainWindow, QHeaderView, qApp, QMenu, QActionGroup, QAction, QStyle, QListWidgetItem, \
@@ -1068,14 +1068,17 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     # HELP
     ###############################################################################
 
+    def centerChildWindow(self, win):
+        r = win.geometry()
+        r2 = self.geometry()
+        win.move(r2.center() - QPoint(r.width()/2, r.height()/2))
+
     def about(self):
         self.dialog = aboutDialog(mw=self)
         self.dialog.setFixedSize(self.dialog.size())
         self.dialog.show()
         # Center about dialog
-        r = self.dialog.geometry()
-        r2 = self.geometry()
-        self.dialog.move(r2.center() - r.center())
+        self.centerChildWindow(self.dialog)
 
     ###############################################################################
     # GENERAL AKA UNSORTED
@@ -1364,9 +1367,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.sw.hide()
         self.sw.setWindowModality(Qt.ApplicationModal)
         self.sw.setWindowFlags(Qt.Dialog)
-        r = self.sw.geometry()
-        r2 = self.geometry()
-        self.sw.move(r2.center() - r.center())
+        self.centerChildWindow(self.sw)
         if tab:
             self.sw.setTab(tab)
         self.sw.show()
@@ -1508,15 +1509,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def doImport(self):
         self.dialog = importerDialog(mw=self)
         self.dialog.show()
+        self.centerChildWindow(self.dialog)
 
-        r = self.dialog.geometry()
-        r2 = self.geometry()
-        self.dialog.move(r2.center() - r.center())
 
     def doCompile(self):
         self.dialog = exporterDialog(mw=self)
         self.dialog.show()
-
-        r = self.dialog.geometry()
-        r2 = self.geometry()
-        self.dialog.move(r2.center() - r.center())
+        self.centerChildWindow(self.dialog)

--- a/manuskript/ui/exporters/exporter.py
+++ b/manuskript/ui/exporters/exporter.py
@@ -3,7 +3,7 @@
 import json
 import os
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QPoint
 from PyQt5.QtGui import QBrush, QColor, QIcon
 from PyQt5.QtWidgets import QWidget, QStyle
 
@@ -138,7 +138,7 @@ class exporterDialog(QWidget, Ui_exporter):
 
         r = self.dialog.geometry()
         r2 = self.geometry()
-        self.dialog.move(r2.center() - r.center())
+        self.dialog.move(r2.center() - QPoint(r.width()/2, r.height()/2))
 
         self.dialog.exportersMightHaveChanged.connect(self.populateExportList)
 


### PR DESCRIPTION
The About/Settings/Import/Export/ExportManager windows were all created
in odd places, usually to the left of the main window, which meant outside the
desktop area with little overlap if the main window is maximized. The logic in
centering the window on its parent was wrong. This fixes it.