### PR TITLE
Fix pandoc export crashes is project title is empty

### DIFF
--- a/manuskript/exporter/pandoc/__init__.py
+++ b/manuskript/exporter/pandoc/__init__.py
@@ -74,8 +74,11 @@ class pandocExporter(basicExporter):
             if var and item and item.text().strip():
                 args.append("--variable={}:{}".format(var, item.text().strip()))
 
-        # Add title metatadata required for pandoc >= 2.x
-        args.append("--metadata=title:{}".format(mainWindow().mdlFlatData.item(0, 0).text().strip()))
+        # Add title metadata required for pandoc >= 2.x
+        title = "Untitled"
+        if mainWindow().mdlFlatData.item(0, 0):
+            title = mainWindow().mdlFlatData.item(0, 0).text().strip()
+        args.append("--metadata=title:{}".format(title))
 
         qApp.setOverrideCursor(QCursor(Qt.WaitCursor))
 


### PR DESCRIPTION
This PR prevents the crash mentioned in issue #535.

For test steps  see [issue 535 - steps to reproduce crash](https://github.com/olivierkes/manuskript/issues/535#issuecomment-493785776).
