### PR TITLE
fix issue #468 'unit' is reset

### DIFF
--- a/manuskript/ui/welcome.py
+++ b/manuskript/ui/welcome.py
@@ -286,18 +286,19 @@ class welcome(QWidget, Ui_welcome):
 
         k = 0
         hasWC = False
-        for d in self.template[1]:
+        for templateIndex, d in enumerate(self.template[1]):
             spin = QSpinBox(self)
             spin.setRange(0, 999999)
             spin.setValue(d[0])
             # Storing the level of the template in that spinbox, so we can use
             # it to update the template when valueChanged on that spinbox
             # (we do that in self.updateWordCount for convenience).
-            spin.setProperty("templateIndex", self.template[1].index(d))
+            spin.setProperty("templateIndex", templateIndex)
             spin.valueChanged.connect(self.updateWordCount)
-
             if d[1] != None:
                 txt = QLineEdit(self)
+                txt.setProperty("templateIndex", templateIndex)
+                txt.textEdited.connect(self.updateWordCount)
                 txt.setText(d[1])
 
             else:
@@ -360,11 +361,20 @@ class welcome(QWidget, Ui_welcome):
                                    Qt.FindChildrenRecursively):
             total = total * s.value()
 
-            # Update self.template to reflect the changed values
+            # Update self.template to reflect the changed count values
             templateIndex = s.property("templateIndex")
             self.template[1][templateIndex] = (
                 s.value(),
                 self.template[1][templateIndex][1])
+
+        for t in self.findChildren(QLineEdit, QRegExp(".*"),
+                                   Qt.FindChildrenRecursively):
+            # Update self.template to reflect the changed name values
+            templateIndex = t.property("templateIndex")
+            if templateIndex is not None :
+                self.template[1][templateIndex] = (
+                self.template[1][templateIndex][0],
+                t.text())
 
         if total == 1:
             total = 0


### PR DESCRIPTION
Hello, My apologizes I haven't contributed to anything outside of work before so I'm not sure please let me know if I miss some proper etiquette. 

This issue resolves two problems, the first not mentioned (but related) to issue 468 was caused by code in welcome.py, mainly line 296 

    spin.setProperty("templateIndex", self.template[1].index(d))

The value of d was often the same for each tuple in template[1], usually 10, so every spinner was storing the first location where 10 was found in template[1].

If the spinner values were initially 1,2,10,10,10, and you changed them to be, 1,2,3,4,5, the "index(d)" would only see index 3 for the 10s, and it would run the connect function 3 times, updating index three with the value "5" on its last run resulting in 1,2,5,10,10.

Adding enumeration and using the actual index instead of deriving the index with the index() function resolves the problem completely.  

Line 289 and 296 are all that are needed to resolve that issue.

And the second issue from 468 is that changes to the naming conventions aren't saved.  This is because there simply doesn't seem to have been any intention to do so in the code.  To resolve the issue I followed the same practice that had originally been done with the spinners, though for the QLineEdit values it sometimes resulted in a "None" being returned, which caused an error so I filtered None out with an if statement.

(I had to amend my commit as I had left some stuff in there that wasn't necessary, a print statement and an blank line)