### PR TITLE
Fix crash when setting word Goal on new Text (scene) in Outline pane

### DIFF
--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -57,7 +57,8 @@ def drawProgress(painter, rect, progress, radius=0):
     painter.setBrush(QBrush(colorFromProgress(progress)))
 
     r2 = QRect(rect)
-    r2.setWidth(r2.width() * min(progress, 1))
+    r2.setWidth(r2.width() * min(toInt(progress), 1))
+    #                            ^^^^^ Avoid crash - issue #561
     painter.drawRoundedRect(r2, radius, radius)
 
 

--- a/manuskript/ui/editors/mainEditor.py
+++ b/manuskript/ui/editors/mainEditor.py
@@ -9,7 +9,7 @@ from PyQt5.QtWidgets import QWidget, qApp
 
 from manuskript import settings
 from manuskript.enums import Outline
-from manuskript.functions import AUC, mainWindow, drawProgress, appPath
+from manuskript.functions import AUC, mainWindow, drawProgress, appPath, toInt
 from manuskript.ui import style
 from manuskript.ui.editors.editorWidget import editorWidget
 from manuskript.ui.editors.fullScreenEditor import fullScreenEditor
@@ -319,7 +319,8 @@ class mainEditor(QWidget, Ui_mainEditor):
             self.lblRedacProgress.setPixmap(self.px)
             self.lblRedacWC.setText(self.tr("{} words / {} ").format(
                     locale.format_string("%d", wc, grouping=True),
-                    locale.format_string("%d", goal, grouping=True)))
+                    locale.format_string("%d", toInt(goal), grouping=True)))
+                    #                          ^^^^^ Avoid crash - issue #561
         else:
             self.lblRedacProgress.hide()
             self.lblRedacWC.setText(self.tr("{} words ").format(


### PR DESCRIPTION
See issue #561.

The problem appears to be a due to a combination of factors, such as:

- Python does not automatically convert an empty/blank variable to the
  integer zero (0)
- Default goal value is empty/blank for a new Text (scene)
- Asynchronous events can occur such that the change in the Outline
  pane of a new Text (scene) goal from empty/blank to a value is not
  saved to the data model prior to the update event in the Editor pane
  accessing the model value for the word count progress display.

Steps to Reproduce:

1. Start manuskript and create new project (no template).

2. Select **Outline** pane.

3. Click "Text Plus" icon to create a text (default name "New")

4. Select **Editor** pane.

5. Click on **New** to display empty text.

6. Select **Outline** pane.

7. Double-click the empty area on **New** line under title **Goal**,
  type in "300", and press **Enter**.

   Note that manuskript crashes with a segmentation fault.

Work around the crash by using the already existing manuskript
function toInt() which handles conversion of empty/blank values to
integer value zero (0).