### PR TITLE
Fix Linux Travis CI build error - pyenv: version `3.6.3' not installed

### DIFF
--- a/package/prepare_linux.sh
+++ b/package/prepare_linux.sh
@@ -5,7 +5,7 @@ sudo apt-get -qq install python3-pip python3-dev \
      build-essential qt5-default libxml2-dev libxslt1-dev \
      mesa-utils libgl1-mesa-glx libgl1-mesa-dev
 
-pyenv local 3.6.3
+pyenv local 3.6.7
 python --version
 easy_install pip
 pip install pyqt5==5.9 lxml pytest pytest-faulthandler


### PR DESCRIPTION
The Linux Travis CI builds are failing with the following messages:

    pyenv local 3.6.3
    pyenv: version `3.6.3' not installed

Fix by increasing python version to 3.6.7.