### PR TITLE
Working Pandoc import (fixes #611) & small dialog UI update.

### DIFF
--- a/manuskript/ui/importers/importer.py
+++ b/manuskript/ui/importers/importer.py
@@ -122,9 +122,8 @@ class importerDialog(QWidget, Ui_importer):
         F = self._format
 
         options = QFileDialog.Options()
-        options |= QFileDialog.DontUseNativeDialog
         if F.fileFormat == "<<folder>>":
-            options = QFileDialog.DontUseNativeDialog | QFileDialog.ShowDirsOnly
+            options = QFileDialog.ShowDirsOnly
             fileName = QFileDialog.getExistingDirectory(self, "Select import folder",
                                                         "", options=options)
         else:

--- a/manuskript/ui/importers/importer.py
+++ b/manuskript/ui/importers/importer.py
@@ -196,8 +196,8 @@ class importerDialog(QWidget, Ui_importer):
         self.grpPreview.setEnabled(True)
 
         self.settingsWidget = generalSettings()
-        #TODO: custom format widget
-        # self.settingsWidget = F.settingsWidget(self.settingsWidget)
+        #TODO: custom format widget to match exporter visuals?
+        self.settingsWidget = F.settingsWidget(self.settingsWidget)
 
         # Set the settings widget in place
         self.setGroupWidget(self.grpSettings, self.settingsWidget)


### PR DESCRIPTION
Once I realized I didn't need to waste a full day trying to compile Qt & PyQt from scratch, fixing issue #611 was a breeze.

Because a single line fix is a bit disappointing for a PR, I figured I'd also make sure to have the FileDialog used by the Import screen match the look of the native operating system like everywhere else in Manuskript does. It is but a small change, but at least I can now pretend to have something to show for a full days worth of headache. 😉

Using these changes, I have tested importing a Markdown file using Pandoc using both formatTo=OPML and formatTo=markdown, and both seemed to result in a successful import for me.

There is no doubt plenty of work to be done, but at least we can have the functionality back in the upcoming 0.10.0 once more. 

IMHO, the following is work that needs doing in the future where the Import UI is concerned:

- Any warnings / errors thrown by pandoc pop into the console; we definitely want to user-facing at some point

- We also need to polish the UI. perhaps to better match the exporter... assuming the exporter UI is what we want, which I am not sure it is. Currently they look similar, but aren't quite similar at all. This might throw users off. Right now the visual layout is unsatisfactory (albeit functional)... but fixing that is a bit too much for me to tackle at present.