### PR TITLE
Fix exports silently overwriting files (fixes #608) & small fix to dialog logic

### DIFF
--- a/manuskript/exporter/manuskript/HTML.py
+++ b/manuskript/exporter/manuskript/HTML.py
@@ -21,6 +21,7 @@ class HTML(markdown):
 
     exportVarName = "lastManuskriptHTML"
     exportFilter = "HTML files (*.html);; Any files (*)"
+    exportDefaultSuffix = ".html"
 
     def isValid(self):
         return MD is not None

--- a/manuskript/exporter/manuskript/markdown.py
+++ b/manuskript/exporter/manuskript/markdown.py
@@ -16,6 +16,7 @@ class markdown(plainText):
 
     exportVarName = "lastManuskriptMarkdown"
     exportFilter = "Markdown files (*.md);; Any files (*)"
+    exportDefaultSuffix = ".md"
     icon = "text-x-markdown"
 
     def settingsWidget(self):

--- a/manuskript/exporter/manuskript/plainText.py
+++ b/manuskript/exporter/manuskript/plainText.py
@@ -5,7 +5,7 @@ from PyQt5.QtGui import QFont, QTextCharFormat
 from PyQt5.QtWidgets import QPlainTextEdit, qApp, QFrame, QFileDialog, QMessageBox
 
 from manuskript.exporter.basic import basicFormat
-from manuskript.functions import mainWindow
+from manuskript.functions import mainWindow, getSaveFileNameWithSuffix
 from manuskript.models import outlineItem
 from manuskript.ui.exporters.manuskript.plainTextSettings import exporterSettings
 import codecs
@@ -24,6 +24,7 @@ class plainText(basicFormat):
     # Default settings used in self.getExportFilename. For easy subclassing when exporting plaintext.
     exportVarName = "lastPlainText"
     exportFilter = "Text files (*.txt);; Any files (*)"
+    exportDefaultSuffix = ".txt"  # qt ignores the period, but it is clearer in our code to have it
 
     def __init__(self):
         pass
@@ -64,27 +65,15 @@ class plainText(basicFormat):
         else:
             filename = ""
 
-        filename, filter = QFileDialog.getSaveFileName(settingsWidget.parent(),
-                                                       caption=qApp.translate("Export", "Choose output file…"),
-                                                       filter=filter,
-                                                       directory=filename)
+        filename, filter = getSaveFileNameWithSuffix(settingsWidget.parent(),
+                                                     caption=qApp.translate("Export", "Choose output file…"),
+                                                     filter=filter,
+                                                     directory=filename,
+                                                     defaultSuffix=self.exportDefaultSuffix)
 
         if filename:
             s[varName] = filename
             settingsWidget.settings["Output"] = s
-
-            # Auto adds extension if necessary
-            try:
-                # Extract the extension from "Some name (*.ext)"
-                ext = filter.split("(")[1].split(")")[0]
-                ext = ext.split(".")[1]
-                if " " in ext:  # In case there are multiple extensions: "Images (*.png *.jpg)"
-                    ext = ext.split(" ")[0]
-            except:
-                ext = ""
-
-            if ext and filename[-len(ext)-1:] != ".{}".format(ext):
-                filename += "." + ext
 
         # Save settings
         settingsWidget.writeSettings()

--- a/manuskript/exporter/manuskript/plainText.py
+++ b/manuskript/exporter/manuskript/plainText.py
@@ -75,8 +75,8 @@ class plainText(basicFormat):
             s[varName] = filename
             settingsWidget.settings["Output"] = s
 
-        # Save settings
-        settingsWidget.writeSettings()
+            # Save settings
+            settingsWidget.writeSettings()
 
         return filename
 
@@ -84,14 +84,15 @@ class plainText(basicFormat):
         settings = settingsWidget.getSettings()
 
         filename = self.getExportFilename(settingsWidget)
-        settingsWidget.writeSettings()
-        content = self.output(settingsWidget)
-
-        if not content:
-            print("Error: No content. Nothing saved.")
-            return
 
         if filename:
+            settingsWidget.writeSettings()
+            content = self.output(settingsWidget)
+
+            if not content:
+                print("Error: No content. Nothing saved.")
+                return
+
             with open(filename, "w", encoding='utf8') as f:
                 f.write(content)
 

--- a/manuskript/exporter/pandoc/HTML.py
+++ b/manuskript/exporter/pandoc/HTML.py
@@ -16,6 +16,7 @@ class HTML(abstractPlainText):
     exportVarName = "lastPandocHTML"
     toFormat = "html"
     exportFilter = "HTML files (*.html);; Any files (*)"
+    exportDefaultSuffix = ".html"
     requires = {
         "Settings": True,
         "Preview": True,

--- a/manuskript/exporter/pandoc/PDF.py
+++ b/manuskript/exporter/pandoc/PDF.py
@@ -23,6 +23,7 @@ class PDF(abstractOutput):
     exportVarName = "lastPandocPDF"
     toFormat = "pdf"
     exportFilter = "PDF files (*.pdf);; Any files (*)"
+    exportDefaultSuffix = ".pdf"
     requires = {
         "Settings": True,
         "Preview": True,

--- a/manuskript/exporter/pandoc/abstractOutput.py
+++ b/manuskript/exporter/pandoc/abstractOutput.py
@@ -10,6 +10,7 @@ class abstractOutput(abstractPlainText):
     toFormat = "SUBCLASSME"
     icon = "SUBCLASSME"
     exportFilter = "SUBCLASSME"
+    exportDefaultSuffix = ".SUBCLASSME"
     requires = {
         "Settings": True,
         "Preview": False,

--- a/manuskript/exporter/pandoc/abstractPlainText.py
+++ b/manuskript/exporter/pandoc/abstractPlainText.py
@@ -16,6 +16,7 @@ class abstractPlainText(markdown):
     toFormat = "SUBCLASSME"
     icon = "SUBCLASSME"
     exportFilter = "SUBCLASSME"
+    exportDefaultSuffix = ".SUBCLASSME"
 
     def __init__(self, exporter):
         self.exporter = exporter

--- a/manuskript/exporter/pandoc/outputFormats.py
+++ b/manuskript/exporter/pandoc/outputFormats.py
@@ -13,6 +13,7 @@ class ePub(abstractOutput):
     exportVarName = "lastPandocePub"
     toFormat = "epub"
     exportFilter = "ePub files (*.epub);; Any files (*)"
+    exportDefaultSuffix = ".epub"
 
 
 class OpenDocument(abstractOutput):
@@ -23,6 +24,7 @@ class OpenDocument(abstractOutput):
     toFormat = "odt"
     icon = "application-vnd.oasis.opendocument.text"
     exportFilter = "OpenDocument files (*.odt);; Any files (*)"
+    exportDefaultSuffix = ".odt"
 
 
 class DocX(abstractOutput):
@@ -33,4 +35,5 @@ class DocX(abstractOutput):
     toFormat = "docx"
     icon = "application-vnd.openxmlformats-officedocument.wordprocessingml.document"
     exportFilter = "DocX files (*.docx);; Any files (*)"
+    exportDefaultSuffix = ".docx"
 

--- a/manuskript/exporter/pandoc/plainText.py
+++ b/manuskript/exporter/pandoc/plainText.py
@@ -14,6 +14,7 @@ class markdown(abstractPlainText):
     exportVarName = "lastPandocMarkdown"
     toFormat = "markdown"
     exportFilter = "Markdown files (*.md);; Any files (*)"
+    exportDefaultSuffix = ".md"
 
 
 class reST(abstractPlainText):
@@ -24,6 +25,7 @@ class reST(abstractPlainText):
     toFormat = "rst"
     icon = "text-plain"
     exportFilter = "reST files (*.rst);; Any files (*)"
+    exportDefaultSuffix = ".rst"
 
 
 class latex(abstractPlainText):
@@ -35,6 +37,7 @@ class latex(abstractPlainText):
     toFormat = "latex"
     icon = "text-x-tex"
     exportFilter = "Tex files (*.tex);; Any files (*)"
+    exportDefaultSuffix = ".tex"
 
 
 class OPML(abstractPlainText):
@@ -47,5 +50,5 @@ class OPML(abstractPlainText):
     toFormat = "opml"
     icon = "text-x-opml+xml"
     exportFilter = "OPML files (*.opml);; Any files (*)"
-
+    exportDefaultSuffix = ".opml"
 

--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -399,7 +399,8 @@ def getSaveFileNameWithSuffix(parent, caption, directory, filter, options=None, 
     if defaultSuffix:
         dialog.setDefaultSuffix(defaultSuffix)
     dialog.setFileMode(QFileDialog.AnyFile)
-    dialog.setSupportedSchemes(("file",))
+    if hasattr(dialog, 'setSupportedSchemes'): # Pre-Qt5.6 lacks this.
+        dialog.setSupportedSchemes(("file",))
     dialog.setAcceptMode(QFileDialog.AcceptSave)
     if selectedFilter:
         dialog.selectNameFilter(selectedFilter)

--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -9,7 +9,7 @@ from PyQt5.QtCore import Qt, QRect, QStandardPaths, QObject, QRegExp, QDir
 from PyQt5.QtCore import QUrl, QTimer
 from PyQt5.QtGui import QBrush, QIcon, QPainter, QColor, QImage, QPixmap
 from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import qApp, QTextEdit
+from PyQt5.QtWidgets import qApp, QFileDialog, QTextEdit
 
 from manuskript.enums import Outline
 
@@ -385,6 +385,27 @@ def openURL(url):
     Opens url (string) in browser using desktop default application.
     """
     QDesktopServices.openUrl(QUrl(url))
+
+def getSaveFileNameWithSuffix(parent, caption, directory, filter, options=None, selectedFilter=None, defaultSuffix=None):
+    """
+    A reimplemented version of QFileDialog.getSaveFileName() because we would like to make use
+    of the QFileDialog.defaultSuffix property that getSaveFileName() does not let us adjust.
+
+    Note: knowing the selected filter is not an invitation to change the chosen filename later.
+    """
+    dialog = QFileDialog(parent=parent, caption=caption, directory=directory, filter=filter)
+    if options:
+        dialog.setOptions(options)
+    if defaultSuffix:
+        dialog.setDefaultSuffix(defaultSuffix)
+    dialog.setFileMode(QFileDialog.AnyFile)
+    dialog.setSupportedSchemes(("file",))
+    dialog.setAcceptMode(QFileDialog.AcceptSave)
+    if selectedFilter:
+        dialog.selectNameFilter(selectedFilter)
+    if (dialog.exec() == QFileDialog.Accepted):
+        return dialog.selectedFiles()[0], dialog.selectedNameFilter()
+    return None, None
 
 def inspect():
     """


### PR DESCRIPTION
**Note: This has only been tested on Windows 10. While I expect no differences in earlier Windows versions, someone should definitely test whether this behaves as expected on other platforms like Linux.**

This fixes issue #608.

The code was adding on a suffix after the user had already settled on a filename through the QFileDialog presented to them. Besides the fact that changing the filename after the fact is sneaky as hell and betrays user expectations, the functionality we wanted already existed in QFileDialog to begin with.

Using the blame functionality, I can't find a reason why it was implemented the way it currently is. My best assumption is that it was believed this functionality did not exist due to QFileDialog.getSaveFileName() helper not exposing the setting, and that the given solution might be based on an early expectation of the dialog showing all sorts of different filters.

It is worth noting that the functionality we originally implemented theoretically supported a default suffix based on the chosen filter which is not the case for the functionality exposed by QFileDialog, but since all of our dialogs only expose a single filter anyways it is a moot point. It is definitely not worth working out a logic loop where the window closes, we ask for an override (perhaps risking bothering the user on the matter twice), and then re-opening the dialog to let them select something else in the case that they had answered negatively.

[This bug report](https://bugreports.qt.io/browse/QTBUG-11352) from 2011 shows someone tackling the exact same issue, and based on what I can see of the QFileDialog documentation (which is for 90% filled with 'TODO' in [the case of PyQt5](https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtwidgets/qfiledialog.html), so I also crosschecked with [the PyQt4 documentation](https://www.riverbankcomputing.com/static/Docs/PyQt4/qfiledialog.html)), nothing of note has changed that affects this scenario.

As such, simply relying on the most basic functionality available seems like the most sensible choice. Thus ripping out code and relying on a basic, existing solution instead.

(Also, the stowaway commit included means we no longer run the conversion process after canceling the dialog now for the majority of filters. I figured that was worth having in the upcoming v0.10.0 version.)