### PR TITLE
Do not prompt "Save project?" when _Save on quit_ setting enabled

### DIFF
--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -682,8 +682,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             return
 
         # Make sure data is saved.
-        if not self.handleUnsavedChanges():
-            return  # user
+        if (self.projectDirty and settings.saveOnQuit == True):
+             self.saveDatas()
+        elif not self.handleUnsavedChanges():
+             return  # user cancelled action
 
         # Close open tabs in editor
         self.mainEditor.closeAllTabs()

--- a/manuskript/settings.py
+++ b/manuskript/settings.py
@@ -138,6 +138,7 @@ def save(filename=None, protocol=None):
         "openIndexes": openIndexes,
         "autoSave":autoSave,
         "autoSaveDelay":autoSaveDelay,
+        # TODO: Settings Cleanup Task -- Rename saveOnQuit to saveOnProjectClose -- see PR #615
         "saveOnQuit":saveOnQuit,
         "autoSaveNoChanges":autoSaveNoChanges,
         "autoSaveNoChangesDelay":autoSaveNoChangesDelay,

--- a/manuskript/ui/settings_ui.py
+++ b/manuskript/ui/settings_ui.py
@@ -1854,7 +1854,7 @@ class Ui_Settings(object):
         self.label.setText(_translate("Settings", "minutes."))
         self.chkAutoSaveNoChanges.setText(_translate("Settings", "If no changes during"))
         self.label_14.setText(_translate("Settings", "seconds."))
-        self.chkSaveOnQuit.setText(_translate("Settings", "Save on quit"))
+        self.chkSaveOnQuit.setText(_translate("Settings", "Save on project close"))
         self.chkSaveToZip.setToolTip(_translate("Settings", "<html><head/><body><p>If you check this option, your project will be save as one single file. Easier to copy or backup, but does not allow collaborative editing, or versionning.<br/>If this is unchecked, your project will be save as a folder containing many small files.</p></body></html>"))
         self.chkSaveToZip.setText(_translate("Settings", "Save to one single file"))
         self.lblTitleGeneral_2.setText(_translate("Settings", "Revisions"))

--- a/manuskript/ui/settings_ui.ui
+++ b/manuskript/ui/settings_ui.ui
@@ -407,7 +407,7 @@
              </font>
             </property>
             <property name="text">
-             <string>Save on quit</string>
+             <string>Save on project close</string>
             </property>
             <property name="checked">
              <bool>true</bool>


### PR DESCRIPTION
The Travis CI tests began failing after merging Pull Request #583.

Log snippet:

```
...
Ref not implemented
PASSED
manuskript/tests/ui/test_welcome.py::test_autoLoad QXcbConnection: XCB error: 8 (BadMatch), sequence: 613, resource id: 2097162, major code: 42 (SetInputFocus), minor code: 0
QXcbConnection: XCB error: 8 (BadMatch), sequence: 619, resource id: 2097168, major code: 42 (SetInputFocus), minor code: 0
QXcbConnection: XCB error: 8 (BadMatch), sequence: 625, resource id: 2097171, major code: 42 (SetInputFocus), minor code: 0
```

When I run the "pytest -vs" locally, a command used in our .travis.yml
file, a dialog to "Save project?" is displayed.  Because the test
scripts use the "saveOnQuit" default setting of *enabled*, the
"Save project?" dialog should not be displayed.  Hence it appears that
we have a logic issue when closing the project in Travis CI.

In other words when a call is made to close the project, we are
incorrectly prompted "Save project?" because the dirtyProject flag is
set, but so too is saveOnQuit set to True.  What should happen is an
automatic save with no prompt.  This PR fixes this logic problem so
that the Travis CI test suite completes successfully.

This PR ready for review