### PR TITLE
Reworking of the translation loading process (issue #619)

### DIFF
--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -41,30 +41,33 @@ def prepare(tests=False):
     appTranslator = QTranslator(app)
     # By default: locale
 
-    def extractLocale(filename):
-        # len("manuskript_") = 13, len(".qm") = 3
-        return filename[11:-3] if len(filename) >= 16 else ""
-
     def tryLoadTranslation(translation, source):
-        if appTranslator.load(appPath(os.path.join("i18n", translation))):
+        if appTranslator.load(translation, appPath("i18n")):
             app.installTranslator(appTranslator)
-            print(app.tr("Loaded translation from {}: {}.").format(source, translation))
+            print("Loaded translation: {}".format(translation))
             return True
         else:
-            print(app.tr("Note: No translator found or loaded from {} for locale {}.").
-                  format(source, extractLocale(translation)))
+            print("No translation found or loaded. ({})".format(translation))
             return False
 
-    # Load translation from settings
+    # Load application translation
     translation = ""
+    source = "default"
     if settings.contains("applicationTranslation"):
+        # Use the language configured by the user.
         translation = settings.value("applicationTranslation")
-        print("Found translation in settings:", translation)
-
-    if (translation != "" and not tryLoadTranslation(translation, "settings")) or translation == "":
-        # load from settings failed or not set, fallback
+        source = "user setting"
+    else:
+        # Auto-detect based on system locale.
         translation = "manuskript_{}.qm".format(locale)
-        tryLoadTranslation(translation, "system locale")
+        source = "system locale"
+        # Note: a missing translation should default to builtin translation,
+        #   meaning a missing 'manuskript_en_US.qm' is not a problem at all.
+
+    print("Preferred translation: {} (based on {})".format(("builtin" if translation == "" else translation), source))
+    if (translation != ""):  # empty string == 'no translation, use builtin'
+        if not tryLoadTranslation(translation, source):
+            print("Falling back on the builtin translation.")
 
     QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + [appPath("icons")])
     QIcon.setThemeName("NumixMsk")


### PR DESCRIPTION
Two patches for the price of one. 😄 

The first is a bugfix for issue #619. I never had the original issue, so I cannot confirm it fixed... but it definitely should be.

The second is an improvement in functionality to more accurately determine the language to show a user by basing the language to show off of the preferred UI language as opposed to the system locale.

Additionally, this adjusts the messages emitted to the console to make it more clear what is happening. (The old messages just confused me too much while I was working on the code, sorry!)

I have tested this PR on Windows 10, but Mac and Linux probably need some love still.

For the auto-detection, I did this by removing the 'applicationTranslation' setting manually in the registry (the Manuskript UI only lets you set it to an empty string, which corresponds to the builtin 'US English' selection. I did not feel it necessary to add something UI-side to reflect this settings 'null state' since any normal user would just select the language they need and be done with it. 😁 