### PR TITLE
Move Qt 5.11 / 5.12 version warning to Import invocation

### DIFF
--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -4,48 +4,16 @@ import faulthandler
 import os
 import platform
 import sys
-import re
 
 import manuskript.ui.views.webView
-from PyQt5.Qt import qVersion
 from PyQt5.QtCore import QLocale, QTranslator, QSettings, Qt
 from PyQt5.QtGui import QIcon, QColor, QPalette
-from PyQt5.QtWidgets import QApplication, qApp, QMessageBox, QStyleFactory
+from PyQt5.QtWidgets import QApplication, qApp, QStyleFactory
 
 from manuskript.functions import appPath, writablePath
 from manuskript.version import getVersion
 
 faulthandler.enable()
-
-def warnAboutBuggyLibraries(app):
-    """Some bugs are out of our reach to fix. The user needs to be warned and perhaps take action themselves."""
-
-    # (Py)Qt 5.11 and 5.12 have a bug that can cause crashes when simply setting up
-    # various UI elements. This has been reported and verified to happen in the
-    # Export (Compile) screen, but due to the nature of the bug, we cannot be sure
-    # it won't cause random crashes in other parts of the application. (PR-612)
-
-    if re.match("^5\\.1[12](\\.?|$)", qVersion()):
-        warning1 = "The version of PyQt you are using ({}) is known to have a bug that can cause Manuskript to crash."
-        warning2 = "It is recommended that you upgrade to the latest version of PyQt."
-
-        # Don't translate for debug log.
-        print("WARNING:", warning1.format(qVersion()), warning2)
-
-        msg = QMessageBox(QMessageBox.Warning,
-            app.tr("You may experience crashes."),
-            "<p><b>" +
-                app.tr(warning1).format(qVersion()) +
-            "</b></p>" +
-            "<p>" +
-                app.tr(warning2) +
-            "</p>",
-            QMessageBox.Ignore | QMessageBox.Abort)
-
-        # Dialogs without a choice on them are just asking to be ignored...
-        # But with the option to 'Abort'...? Maybe someone will actually read it.
-        if msg.exec() == QMessageBox.Abort:
-            sys.exit(1)
 
 def prepare(tests=False):
     app = QApplication(sys.argv)
@@ -199,7 +167,6 @@ def prepare(tests=False):
     return app, MW
 
 def launch(app, MW = None):
-    warnAboutBuggyLibraries(app)
 
     if MW is None:
         from manuskript.functions import mainWindow


### PR DESCRIPTION
See issue #611

The warning previously added in PR #612 for Manuskript users with Qt 5.11 / 5.12 has shown itself, in my opinion, to be overly annoying.  This is because the warning *always* displays on systems with the affected Qt versions even though the crash is verified to happen with the import feature only.

Additionally the process to upgrade to a newer version of PyQt / Qt is not trivial for users who rely on pre-built packages and do not run from source code.

At time of writing some currently supported OSes with a most recent Qt package version in the Qt 5.11 / 5.12 range are:

| OS  | Qt Version |
| --- | ---------- |
| Debian 10 Buster | [5.11.3](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=qt5-default) |
| Debian 11 Bullseye | [5.11.3](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=qt5-default) |
| Fedora 29 | [5.11.1](https://koji.fedoraproject.org/koji/packageinfo?packageID=22646) |
| Fedora 30 | [5.12.4](https://koji.fedoraproject.org/koji/packageinfo?packageID=22646) |
| Ubuntu 18.10 Cosmic | [5.11.1](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=qt5-default&searchon=names) |
| Ubuntu 19.04 Disco | [5.12.2](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=qt5-default&searchon=names) |

Because the crash has been verified with the Import feature only, limit the scope of the warning to the Import feature.

### Testing

_Test platform: Kubuntu 19.04 with Qt 5.12.2, PyQt 5.12.1, and Python 3.7.3_

In order to see if other areas of Manuskript would crash with Qt 5.11 / 5.12 I performed the following testing:

| Feature | Works? |
| --------| ------ |
| Navigation tabs - data entry | Yes |
| File -> Import | **No** - crash |
| File -> Compile - preview built-in HTML, Pandoc PDF | Yes |
| Edit -> Settings - Views/Text editor/Font size | Yes |
| Organize - Move up/down | Yes |
| View -> Mode - simple/fiction | Yes|
| Tools -> Spellcheck | Yes |
| Tolls -> Frequency analyzer | Yes |
| Help -> Show help texts | Yes |
| Cheatsheet | Yes |
| Search | Yes |
| Story line | Yes |

Based on the above testing only the Import feature appears to crash with Qt 5.11/5.12.  As such this PR moves the Qt version warning to the Import feature invocation.

This PR is ready for review.