### PR TITLE
Fix word recognition for spell checker, ignore active partial words

### DIFF
--- a/manuskript/ui/highlighters/basicHighlighter.py
+++ b/manuskript/ui/highlighters/basicHighlighter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 import re
 
@@ -146,9 +146,12 @@ class BasicHighlighter(QSyntaxHighlighter):
             textedText = text + " "
 
         # Based on http://john.nachtimwald.com/2009/08/22/qplaintextedit-with-in-line-spell-check/
-        WORDS = r'(?iu)(((?!_)[\w\'])+)'
+        WORDS = r'(?iu)((?:[^_\W]|\')+)[^A-Za-z0-9\']'
         #         (?iu) means case insensitive and Unicode
-        #                (?!_) means perform negative lookahead to exclude "_" from pattern match.  See issue #283
+        #              ((?:[^_\W]|\')+) means words exclude underscores but include apostrophes
+        #                              [^A-Za-z0-9\'] used with above hack to prevent spellcheck while typing word
+        #
+        # See also https://stackoverflow.com/questions/2062169/regex-w-in-utf-8
         if hasattr(self.editor, "spellcheck") and self.editor.spellcheck:
             for word_object in re.finditer(WORDS, textedText):
                 if (self.editor._dict


### PR DESCRIPTION
This PR restores the functionality that prevents spell checking a word that is being actively typed at the end of a paragraph.

## History

A problem with the spell checker being invoked on active partial words (e.g., those being typed, but not yet completed) was fixed with issue #166.  However a subsequent fix to ignore underscores in words with issue #283 broke the previous fix.  This commit is intended to fix these issues.

## Goals

The goals for the spell check word match regexp are:

A. Words should include those with an apostrophe  
 &nbsp; &nbsp; &nbsp;   *E.g., can't*
B. Words should exclude underscore  
 &nbsp; &nbsp; &nbsp;   *E.g., hello_world is two words*
C. Words in other languages should be recognized  
 &nbsp; &nbsp; &nbsp;   *E.g., French word familiarisé*
D. Spell check should include word at absolute end of line with no trailing space or punctuation  
 &nbsp; &nbsp; &nbsp;   *E.g., tezt*
E. Spell check should ignore partial words in progress (user typing)  
 &nbsp; &nbsp; &nbsp;   *E.g., paragr while midway through typing paragraph*

## Test Strings

Following are some strings to help test the above goals.

```
A. Words with apostrophe.  Can't for cannot.

B. Words with underscore: _Italic_, _Three word italic_,  hello_world.

C. French words: familiarisé. système a été installé à partir

D. Spell check word at absolute end of line:  Manuskript tezt

E. Spell check ignore active partial word being typed:  Manuskript test.
```

## Test Results

It took a while to craft a regular expression that addresses all five of the above goals.

Note that the regexp being changed is the definition for **WORDS** as used in the file `manuskript/ui/highlighters/basicHighlighter.py`.

https://github.com/olivierkes/manuskript/blob/0943d813172091f77ec13751971bf2ea2c9264ff/manuskript/ui/highlighters/basicHighlighter.py#L139-L151).

### Regexp 1: `(?iu)([\w\']+)[^\'\w]`

Active in Manuskript 0.5.0 to 0.6.0 - see issue #166.

Fails on goal B. `hello_world` is recognized as a single word.

![Regexp-1-test](https://user-images.githubusercontent.com/10405019/65286017-6bb23b80-dafb-11e9-916a-0df24f46947d.png)

Note screen shots created using https://regex101.com/

### Regexp 2: `(?iu)(((?!_)[\w\'])+)`

Active in Manuskript 0.7.0 to 0.9.0 - see issue #283.

Fails on goal E.  Wrongly spell checks actively typed word.

![Regexp-2-test](https://user-images.githubusercontent.com/10405019/65286028-71a81c80-dafb-11e9-90fe-81ae418f5d91.png)

### Regexp 3: `(?iu)((?:[^_\W]|\')+)[^A-Za-z0-9\']`

Proposed new regexp for 0.10.0 inspired from the following link:
https://stackoverflow.com/questions/2062169/regex-w-in-utf-8

Succeeds for all five goals.

![Regexp-3-test](https://user-images.githubusercontent.com/10405019/65286057-7ec50b80-dafb-11e9-960c-0a26948d6c01.png)

### Before Fix Applied

Notice that words are spell checked while being typed.

![Manuskript-Spellcheck-Before-PR](https://user-images.githubusercontent.com/10405019/65286115-a916c900-dafb-11e9-9d1a-f52da3b044c4.gif)

### After Fix Applied

Notice that words are **NOT** spell checked while being typed.  Spell check is only invoked after typing has proceeded beyond the word.

![Manuskript-Spellcheck-After-PR](https://user-images.githubusercontent.com/10405019/65286130-b338c780-dafb-11e9-9969-4f4131986fba.gif)
