### PR TITLE
Fix for Windows 10 Dark Theme on older Qt versions

### DIFF
--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -112,26 +112,26 @@ def prepare(tests=False):
             darkColor = QColor(45,45,45)
             disabledColor = QColor(127,127,127)
             darkPalette.setColor(QPalette.Window, darkColor)
-            darkPalette.setColor(QPalette.WindowText, Qt.GlobalColor.white)
+            darkPalette.setColor(QPalette.WindowText, Qt.white)
             darkPalette.setColor(QPalette.Base, QColor(18,18,18))
             darkPalette.setColor(QPalette.AlternateBase, darkColor)
-            darkPalette.setColor(QPalette.ToolTipBase, Qt.GlobalColor.white)
-            darkPalette.setColor(QPalette.ToolTipText, Qt.GlobalColor.white)
-            darkPalette.setColor(QPalette.Text, Qt.GlobalColor.white)
+            darkPalette.setColor(QPalette.ToolTipBase, Qt.white)
+            darkPalette.setColor(QPalette.ToolTipText, Qt.white)
+            darkPalette.setColor(QPalette.Text, Qt.white)
             darkPalette.setColor(QPalette.Disabled, QPalette.Text, disabledColor)
             darkPalette.setColor(QPalette.Button, darkColor)
-            darkPalette.setColor(QPalette.ButtonText, Qt.GlobalColor.white)
+            darkPalette.setColor(QPalette.ButtonText, Qt.white)
             darkPalette.setColor(QPalette.Disabled, QPalette.ButtonText, disabledColor)
-            darkPalette.setColor(QPalette.BrightText, Qt.GlobalColor.red)
+            darkPalette.setColor(QPalette.BrightText, Qt.red)
             darkPalette.setColor(QPalette.Link, QColor(42, 130, 218))
 
             darkPalette.setColor(QPalette.Highlight, QColor(42, 130, 218))
-            darkPalette.setColor(QPalette.HighlightedText, Qt.GlobalColor.black)
+            darkPalette.setColor(QPalette.HighlightedText, Qt.black)
             darkPalette.setColor(QPalette.Disabled, QPalette.HighlightedText, disabledColor)
 
             # Fixes ugly (not to mention hard to read) disabled menu items.
             # Source: https://bugreports.qt.io/browse/QTBUG-10322?focusedCommentId=371060#comment-371060
-            darkPalette.setColor(QPalette.Disabled, QPalette.Light, Qt.GlobalColor.transparent)
+            darkPalette.setColor(QPalette.Disabled, QPalette.Light, Qt.transparent)
 
             app.setPalette(darkPalette)
 


### PR DESCRIPTION
QtCore.Qt.GlobalColor does not have any accessors for the predefined
colors on PyQt versions before 5.11 despite the object itself existing.

It would have been nice if the documentation* had mentioned that object
being broken on older versions, but I should have tested with even older
versions of PyQt before submitting the original patch.

Apparently the most supported way to access these colors is through the
Qt namespace itself, but those aren't documented in the slightest. Ugh.

My apologies to all those affected. Fixes issue #659.

*: https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtcore/qt.html#GlobalColor


@gedakc Can you create a new Windows build with this fix implemented and put it on the website? (I cannot currently test it on Qt 5.5 but since it reproduced on 5.8 I assume this bug is fixed.)

I will look into setting up a proper test environment for Qt5.5 on my end in the future so I won't have to depend on you to test it on older PyQt versions anymore. I should have caught this before I submitted the PR. 😢 