### PR TITLE
Logging and command-line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,14 @@
 .project
 .pydevproject
 .settings/org.eclipse.core.resources.prefs
+.vscode
 ExportTest
 Notes.t2t
 dist
 build
 icons/Numix
 manuskript/pycallgraph.txt
+manuskript.log
 snowflake*
 test-projects
 main.pyproject.user

--- a/manuskript/converters/markdownConverter.py
+++ b/manuskript/converters/markdownConverter.py
@@ -11,6 +11,9 @@ from PyQt5.QtGui import QCursor
 from manuskript.converters import abstractConverter
 from manuskript.functions import mainWindow
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 try:
     import markdown as MD
 except ImportError:
@@ -31,7 +34,7 @@ class markdownConverter(abstractConverter):
     @classmethod
     def convert(self, markdown):
         if not self.isValid:
-            print("ERROR: markdownConverter is called but not valid.")
+            LOGGER.error("markdownConverter is called but not valid.")
             return ""
 
         html = MD.markdown(markdown)

--- a/manuskript/converters/pandocConverter.py
+++ b/manuskript/converters/pandocConverter.py
@@ -11,6 +11,8 @@ from PyQt5.QtGui import QCursor
 from manuskript.converters import abstractConverter
 from manuskript.functions import mainWindow
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class pandocConverter(abstractConverter):
 
@@ -38,7 +40,7 @@ class pandocConverter(abstractConverter):
     @classmethod
     def convert(self, src, _from="markdown", to="html", args=None, outputfile=None):
         if not self.isValid:
-            print("ERROR: pandocConverter is called but not valid.")
+            LOGGER.error("pandocConverter is called but not valid.")
             return ""
 
         cmd = [self.runCmd()]
@@ -70,7 +72,7 @@ class pandocConverter(abstractConverter):
 
         if stderr:
             err = stderr.decode("utf-8")
-            print(err)
+            LOGGER.error(err)
             QMessageBox.critical(mainWindow().dialog,
                                  qApp.translate("Export", "Error"), err)
             return None

--- a/manuskript/exporter/basic.py
+++ b/manuskript/exporter/basic.py
@@ -10,6 +10,8 @@ from PyQt5.QtWidgets import QWidget
 from manuskript.models import outlineItem
 from manuskript.functions import mainWindow
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class basicExporter:
 
@@ -58,7 +60,7 @@ class basicExporter:
         elif self.isValid() == 1:
             run = self.customPath
         else:
-            print("Error: no command for", self.name)
+            LOGGER.error("No command for %s.", self.name)
             return None
         r = subprocess.check_output([run] + args)  # timeout=.2
         return r.decode("utf-8")
@@ -71,7 +73,7 @@ class basicExporter:
         # try:
         #     output = subprocess.check_output(cmdl, stdin=cmd.stdout, stderr=subprocess.STDOUT)  # , cwd="/tmp"
         # except subprocess.CalledProcessError as e:
-        #     print("Error!")
+        #     LOGGER.error("Failed to read from process output.")
         #     return text
         # cmd.wait()
         #

--- a/manuskript/exporter/manuskript/plainText.py
+++ b/manuskript/exporter/manuskript/plainText.py
@@ -10,6 +10,9 @@ from manuskript.models import outlineItem
 from manuskript.ui.exporters.manuskript.plainTextSettings import exporterSettings
 import codecs
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 class plainText(basicFormat):
     name = qApp.translate("Export", "Plain text")
     description = qApp.translate("Export", """Simplest export to plain text. Allows you to use your own markup not understood
@@ -90,7 +93,7 @@ class plainText(basicFormat):
             content = self.output(settingsWidget)
 
             if not content:
-                print("Error: No content. Nothing saved.")
+                LOGGER.error("No content. Nothing saved.")
                 return
 
             with open(filename, "w", encoding='utf8') as f:

--- a/manuskript/exporter/pandoc/__init__.py
+++ b/manuskript/exporter/pandoc/__init__.py
@@ -13,6 +13,8 @@ from manuskript.exporter.pandoc.outputFormats import ePub, OpenDocument, DocX
 from manuskript.exporter.pandoc.plainText import reST, markdown, latex, OPML
 from manuskript.functions import mainWindow
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class pandocExporter(basicExporter):
 
@@ -53,7 +55,7 @@ class pandocExporter(basicExporter):
         elif self.isValid() == 1:
             run = self.customPath
         else:
-            print("Error: no command for pandoc")
+            LOGGER.error("No command for pandoc.")
             return None
         args = [run] + args
 
@@ -101,7 +103,7 @@ class pandocExporter(basicExporter):
                 + "Return code" + ": %d\n" % (p.returncode) \
                 + "Command and parameters" + ":\n%s\n" % (p.args) \
                 + "Stderr content" + ":\n" + stderr.decode("utf-8") 
-            print(err)
+            LOGGER.error(err)
             QMessageBox.critical(mainWindow().dialog, qApp.translate("Export", "Error"), err)
             return None
 

--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -3,6 +3,8 @@
 
 import os
 import re
+import sys
+import pathlib
 from random import *
 
 from PyQt5.QtCore import Qt, QRect, QStandardPaths, QObject, QRegExp, QDir
@@ -12,6 +14,9 @@ from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import qApp, QFileDialog
 
 from manuskript.enums import Outline
+
+import logging
+LOGGER = logging.getLogger(__name__)
 
 # Used to detect multiple connections
 AUC = Qt.AutoConnection | Qt.UniqueConnection
@@ -492,6 +497,48 @@ def getSearchResultContext(text, startPos, endPos):
         context += " " + separator
 
     return context
+
+
+# Based on answer by jfs at:
+#  https://stackoverflow.com/questions/3718657/how-to-properly-determine-current-script-directory
+def getManuskriptPath(follow_symlinks=True):
+    """Used to obtain the path Manuskript is located at."""
+    if getattr(sys, 'frozen', False): # py2exe, PyInstaller, cx_Freeze
+        path = os.path.abspath(sys.executable)
+    else:
+        import inspect
+        path = inspect.getabsfile(getManuskriptPath) + "/../.."
+    if follow_symlinks:
+        path = os.path.realpath(path)
+    return os.path.dirname(path)
+
+# Based on answer by kagronik at:
+#   https://stackoverflow.com/questions/14989858/get-the-current-git-hash-in-a-python-script
+def getGitRevision(base_path):
+    """Get git revision without relying on external processes or libraries."""
+    git_dir = pathlib.Path(base_path) / '.git'
+    if not git_dir.exists():
+        return None
+
+    with (git_dir / 'HEAD').open('r') as head:
+        ref = head.readline().split(' ')[-1].strip()
+
+    with (git_dir / ref).open('r') as git_hash:
+        return git_hash.readline().strip()
+
+def getGitRevisionAsString(base_path, short=False):
+    """Catches errors and presents a nice string."""
+    try:
+        rev = getGitRevision(base_path)
+        if rev is not None:
+            if short:
+                rev = rev[:7]
+            return "#" + rev
+        else:
+            return ""  # not a git repository
+    except Exception as e:
+        LOGGER.warning("Failed to obtain Git revision: %s", e)
+        return "#ERROR"
 
 # Spellchecker loads writablePath from this file, so we need to load it after they get defined
 from manuskript.functions.spellchecker import Spellchecker

--- a/manuskript/loadSave.py
+++ b/manuskript/loadSave.py
@@ -9,6 +9,8 @@ import zipfile
 import manuskript.load_save.version_0 as v0
 import manuskript.load_save.version_1 as v1
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 def saveProject(version=None):
 
@@ -57,8 +59,8 @@ def loadProject(project):
         with open(project, "r", encoding="utf-8") as f:
             version = int(f.read())
 
-    print("Loading:", project)
-    print("Detected file format version: {}. Zip: {}.".format(version, isZip))
+    LOGGER.info("Loading: %s", project)
+    LOGGER.info("Detected file format version: {}. Zip: {}.".format(version, isZip))
 
     if version == 0:
         v0.loadProject(project)

--- a/manuskript/load_save/version_0.py
+++ b/manuskript/load_save/version_0.py
@@ -16,6 +16,9 @@ from manuskript import settings
 from manuskript.functions import iconColor, iconFromColorString, mainWindow
 from manuskript.models.characterModel import Character, CharacterInfo
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 try:
     import zlib  # Used with zipfile for compression
 
@@ -37,7 +40,7 @@ def saveProject():
 
     files.append((saveStandardItemModelXML(mw.mdlFlatData),
                   "flatModel.xml"))
-    print("ERROR: file format 0 does not save characters !")
+    LOGGER.error("File format 0 does not save characters!")
     # files.append((saveStandardItemModelXML(mw.mdlCharacter),
     #               "perso.xml"))
     files.append((saveStandardItemModelXML(mw.mdlWorld),
@@ -91,7 +94,7 @@ def saveStandardItemModelXML(mdl, xml=None):
     data = ET.SubElement(root, "data")
     saveItem(data, mdl)
 
-    # print(qApp.tr("Saving to {}.").format(xml))
+    # LOGGER.info("Saving to {}.".format(xml))
     if xml:
         ET.ElementTree(root).write(xml, encoding="UTF-8", xml_declaration=True, pretty_print=True)
     else:
@@ -189,13 +192,13 @@ def loadStandardItemModelXML(mdl, xml, fromString=False):
     """Load data to a QStandardItemModel mdl from xml.
     By default xml is a filename. If fromString=True, xml is a string containing the data."""
 
-    # print(qApp.tr("Loading {}... ").format(xml), end="")
+    # LOGGER.info("Loading {}...".format(xml))
 
     if not fromString:
         try:
             tree = ET.parse(xml)
         except:
-            print("Failed.")
+            LOGGER.error("Failed to load XML for QStandardItemModel (%s).", xml)
             return
     else:
         root = ET.fromstring(xml)
@@ -210,7 +213,7 @@ def loadStandardItemModelXML(mdl, xml, fromString=False):
     for l in root.find("header").find("vertical").findall("label"):
         vLabels.append(l.attrib["text"])
 
-    # print(root.find("header").find("vertical").text)
+    # LOGGER.debug(root.find("header").find("vertical").text)
 
     # mdl.setVerticalHeaderLabels(vLabels)
     # mdl.setHorizontalHeaderLabels(hLabels)

--- a/manuskript/load_save/version_1.py
+++ b/manuskript/load_save/version_1.py
@@ -26,6 +26,9 @@ from manuskript.load_save.version_0 import loadFilesFromZip
 from manuskript.models.characterModel import CharacterInfo
 from manuskript.models import outlineItem
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 try:
     import zlib  # Used with zipfile for compression
 
@@ -125,7 +128,7 @@ def saveProject(zip=None):
 
     # Sanity check (see PR-583): make sure we actually have a current project.
     if project == None:
-        print("Error: cannot save project because there is no current project in the UI.")
+        LOGGER.error("Cannot save project because there is no current project in the UI.")
         return False
 
     # File format version
@@ -307,7 +310,7 @@ def saveProject(zip=None):
     # not exist, we check the parent folder, because it might be a new project.
     if os.path.exists(project) and not os.access(project, os.W_OK) or \
        not os.path.exists(project) and not os.access(os.path.dirname(project), os.W_OK):
-        print("Error: you don't have write access to save this project there.")
+        LOGGER.error("You don't have write access to save this project there.")
         return False
 
     ####################################################################################################################
@@ -924,7 +927,7 @@ def addTextItems(mdl, odict, parent=None):
             item._lastPath = odict[k + ":lastPath"]
 
         elif not ":lastPath" in k and k != "folder.txt":
-            print("* Strange things in file {}".format(k))
+            LOGGER.debug("Strange things in file %s".format(k))
 
 
 def outlineFromMMD(text, parent):

--- a/manuskript/logging.py
+++ b/manuskript/logging.py
@@ -59,7 +59,7 @@ def logToFile(file_level=logging.DEBUG, logfile=None):
     # log files may not be in our users best interest for the time
     # being. (Unfortunately.)
     try:
-        fh = logging.FileHandler(logfile, mode='w')
+        fh = logging.FileHandler(logfile, mode='w', encoding='utf-8')
         fh.setLevel(file_level)
         fh.setFormatter(logging.Formatter(LOGFORMAT_FILE))
 

--- a/manuskript/logging.py
+++ b/manuskript/logging.py
@@ -157,6 +157,8 @@ def attributesFromOptionalModule(module, *attributes):
         # The list is consumed as a part of the unpacking syntax.
         return v
 
+import pathlib
+
 def logVersionInformation(logger=None):
     """Logs all important runtime information neatly together.
 
@@ -174,8 +176,11 @@ def logVersionInformation(logger=None):
     logger.info("Hardware: %s / %s", machine(), processor())
 
     # Manuskript and Python info.
+    from manuskript.functions import getGitRevisionAsString, getManuskriptPath
     from manuskript.version import getVersion
-    logger.info("Manuskript %s (Python %s)", getVersion(), python_version())
+    logger.info("Manuskript %s%s (Python %s)", getVersion(),
+                    getGitRevisionAsString(getManuskriptPath(), short=True),
+                    python_version())
 
     # Installed Python packages.
 

--- a/manuskript/logging.py
+++ b/manuskript/logging.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+
+# While all logging should be done through the facilities offered by the
+# standard python `logging` module, this module will take care of specific
+# manuskript needs to keep it separate from the rest of the logic.
+
+from manuskript.functions import writablePath
+import os
+import logging
+
+LOGFORMAT_CONSOLE = "%(levelname)s> %(message)s"
+LOGFORMAT_FILE = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+logger = logging.getLogger(__name__)
+
+def setUp(console_level=logging.WARN):
+    """Sets up a convenient environment for logging.
+
+    To console:  >WARNING, plain.        (Only the essence.)"""
+
+    # The root_logger should merely trigger on warnings since it is the final
+    # stop after all categories we really care about didn't match.
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.WARN)
+    # The manuskript_logger is what all of our own code will come by.
+    # Obviously, we care greatly about logging every single message.
+    manuskript_logger = logging.getLogger("manuskript")
+    manuskript_logger.setLevel(logging.DEBUG)
+    # The qt_logger sees all the Qt nonsense when it breaks.
+    # We don't really want to know... but we have to know.
+    qt_logger = logging.getLogger("qt")
+    qt_logger.setLevel(logging.DEBUG)
+
+    # Send logs of WARNING+ to STDERR for higher visibility.
+    ch = logging.StreamHandler()
+    ch.setLevel(console_level)
+    ch.setFormatter(logging.Formatter(LOGFORMAT_CONSOLE))
+    root_logger.addHandler(ch)
+
+    logger.debug("Logging to STDERR.")
+
+
+def logToFile(file_level=logging.DEBUG, logfile=None):
+    """Sets up the FileHandler that logs to a file.
+
+    This is being done separately due to relying on QApplication being properly
+    configured; without it we cannot detect the proper location for the log file.
+
+    To log file: >DEBUG, timestamped.    (All the details.)"""
+
+    if logfile is None:
+        logfile = os.path.join(writablePath(), "manuskript.log")
+
+    # Log with extreme prejudice; everything goes to the log file.
+    # Because Qt gave me a megabyte-sized logfile while testing, it
+    # makes sense that the default behaviour of appending to existing
+    # log files may not be in our users best interest for the time
+    # being. (Unfortunately.)
+    try:
+        fh = logging.FileHandler(logfile, mode='w')
+        fh.setLevel(file_level)
+        fh.setFormatter(logging.Formatter(LOGFORMAT_FILE))
+
+        root_logger = logging.getLogger()
+        root_logger.addHandler(fh)
+
+        # Use INFO level to make it easier to find for users.
+        logger.info("Logging to file: %s", logfile)
+    except Exception as ex:
+        logger.warning("Cannot log to file '%s'. Reason: %s", logfile, ex)
+
+
+# Qt has its own logging facility that we would like to integrate into our own.
+# See: http://thispageintentionally.blogspot.com/2014/03/trapping-qt-log-messages.html
+
+from PyQt5.QtCore import qInstallMessageHandler, QLibraryInfo, QMessageLogContext
+from PyQt5.Qt import QtMsgType
+
+def qtMessageHandler(msg_type, msg_log_context, msg_string):
+    """Forwards Qt messages to Python logging system."""
+    # Convert Qt msg type to logging level
+    log_level = [logging.DEBUG,
+                 logging.WARNING,
+                 logging.ERROR,
+                 logging.FATAL] [ int(msg_type) ]
+    qtcl = logging.getLogger(msg_log_context.category or "qt.???")
+    # Some information may not be available unless using a PyQt debug build.
+    # See: https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtcore/qmessagelogcontext.html
+    if QLibraryInfo.isDebugBuild():
+        qtcl.log(logging.DEBUG,
+                    ' @ {0} : {1}'.format((msg_log_context.file or "<unknown source file>"), msg_log_context.line)
+                    )
+        qtcl.log(logging.DEBUG,
+                    ' ! {0}'.format((msg_log_context.function or "<unknown function>"))
+                    )
+    qtcl.log(log_level, msg_string)
+
+def integrateQtLogging():
+    """Integrates Qt logging facilities to be a part of our own."""
+
+    # Note: the qtlogger is initialized in setUp() because it fits in
+    # nicely with the initialization of the other loggers over there.
+    # I also feel a lot safer this way. Qt is a curse that just keeps
+    # on giving, even when it isn't actually at fault. I hate you, Qt.
+
+    qInstallMessageHandler(qtMessageHandler)

--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -18,7 +18,7 @@ from manuskript.version import getVersion
 faulthandler.enable()
 
 import logging
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 def prepare(arguments, tests=False):
     app = QApplication(sys.argv)
@@ -34,7 +34,7 @@ def prepare(arguments, tests=False):
     # Handle all sorts of Qt logging messages in Python.
     manuskript.logging.integrateQtLogging()
 
-    logger.info("Running manuskript version {}.".format(getVersion()))
+    LOGGER.info("Running manuskript version {}.".format(getVersion()))
     icon = QIcon()
     for i in [16, 32, 64, 128, 256, 512]:
         icon.addFile(appPath("icons/Manuskript/icon-{}px.png".format(i)))
@@ -57,7 +57,7 @@ def prepare(arguments, tests=False):
         """Tries to load and activate a given translation for use."""
         if appTranslator.load(translation, appPath("i18n")):
             app.installTranslator(appTranslator)
-            logger.info("Loaded translation: {}".format(translation))
+            LOGGER.info("Loaded translation: {}".format(translation))
             # Note: QTranslator.load() does some fancy heuristics where it simplifies
             #   the given locale until it is 'close enough' if the given filename does
             #   not work out. For example, if given 'i18n/manuskript_en_US.qm', it tries:
@@ -72,7 +72,7 @@ def prepare(arguments, tests=False):
             #   filenames when you observe strange behaviour with the loaded translations.
             return True
         else:
-            logger.info("No translation found or loaded. ({})".format(translation))
+            LOGGER.info("No translation found or loaded. ({})".format(translation))
             return False
 
     def activateTranslation(translation, source):
@@ -95,7 +95,7 @@ def prepare(arguments, tests=False):
                         break
 
         if using_builtin_translation:
-            logger.info("Using the builtin translation. (U.S. English)")
+            LOGGER.info("Using the builtin translation. (U.S. English)")
 
     # Load application translation
     translation = ""
@@ -109,7 +109,7 @@ def prepare(arguments, tests=False):
         translation = QLocale().uiLanguages()
         source = "available ui languages"
 
-    logger.info("Preferred translation: {} (based on {})".format(("builtin" if translation == "" else translation), source))
+    LOGGER.info("Preferred translation: {} (based on {})".format(("builtin" if translation == "" else translation), source))
     activateTranslation(translation, source)
 
     def respectSystemDarkThemeSetting():
@@ -241,6 +241,8 @@ def launch(arguments, app, MW = None):
 
 def sigint_handler(sig, MW):
     def handler(*args):
+        # Log before winding down to preserve order of cause and effect.
+        LOGGER.info(f'{sig} received. Quitting...')
         MW.close()
         print(f'{sig} received, quit.')
 

--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -6,6 +6,7 @@ import platform
 import sys
 import signal
 
+import manuskript.logging
 import manuskript.ui.views.webView
 from PyQt5.QtCore import QLocale, QTranslator, QSettings, Qt
 from PyQt5.QtGui import QIcon, QColor, QPalette
@@ -16,15 +17,24 @@ from manuskript.version import getVersion
 
 faulthandler.enable()
 
+import logging
+logger = logging.getLogger(__name__)
 
-def prepare(tests=False):
+def prepare(arguments, tests=False):
     app = QApplication(sys.argv)
     app.setOrganizationName("manuskript" + ("_tests" if tests else ""))
     app.setOrganizationDomain("www.theologeek.ch")
     app.setApplicationName("manuskript" + ("_tests" if tests else ""))
     app.setApplicationVersion(getVersion())
 
-    print("Running manuskript version {}.".format(getVersion()))
+    # Beginning logging to a file. This cannot be done earlier due to the
+    # default location of the log file being dependent on QApplication.
+    manuskript.logging.logToFile(logfile=arguments.logfile)
+
+    # Handle all sorts of Qt logging messages in Python.
+    manuskript.logging.integrateQtLogging()
+
+    logger.info("Running manuskript version {}.".format(getVersion()))
     icon = QIcon()
     for i in [16, 32, 64, 128, 256, 512]:
         icon.addFile(appPath("icons/Manuskript/icon-{}px.png".format(i)))
@@ -47,7 +57,7 @@ def prepare(tests=False):
         """Tries to load and activate a given translation for use."""
         if appTranslator.load(translation, appPath("i18n")):
             app.installTranslator(appTranslator)
-            print("Loaded translation: {}".format(translation))
+            logger.info("Loaded translation: {}".format(translation))
             # Note: QTranslator.load() does some fancy heuristics where it simplifies
             #   the given locale until it is 'close enough' if the given filename does
             #   not work out. For example, if given 'i18n/manuskript_en_US.qm', it tries:
@@ -62,7 +72,7 @@ def prepare(tests=False):
             #   filenames when you observe strange behaviour with the loaded translations.
             return True
         else:
-            print("No translation found or loaded. ({})".format(translation))
+            logger.info("No translation found or loaded. ({})".format(translation))
             return False
 
     def activateTranslation(translation, source):
@@ -85,7 +95,7 @@ def prepare(tests=False):
                         break
 
         if using_builtin_translation:
-            print("Using the builtin translation.")
+            logger.info("Using the builtin translation. (U.S. English)")
 
     # Load application translation
     translation = ""
@@ -99,7 +109,7 @@ def prepare(tests=False):
         translation = QLocale().uiLanguages()
         source = "available ui languages"
 
-    print("Preferred translation: {} (based on {})".format(("builtin" if translation == "" else translation), source))
+    logger.info("Preferred translation: {} (based on {})".format(("builtin" if translation == "" else translation), source))
     activateTranslation(translation, source)
 
     def respectSystemDarkThemeSetting():
@@ -164,15 +174,16 @@ def prepare(tests=False):
     MW._defaultCursorFlashTime = qApp.cursorFlashTime()
 
     # Command line project
-    if len(sys.argv) > 1 and sys.argv[1][-4:] == ".msk":
+    #if len(sys.argv) > 1 and sys.argv[1][-4:] == ".msk":
+    if arguments.filename is not None and arguments.filename[-4:] == ".msk":
+        #TODO: integrate better with argparsing.
         if os.path.exists(sys.argv[1]):
             path = os.path.abspath(sys.argv[1])
             MW._autoLoadProject = path
 
     return app, MW
 
-
-def launch(app, MW=None):
+def launch(arguments, app, MW = None):
     if MW == None:
         from manuskript.functions import mainWindow
         MW = mainWindow()
@@ -184,7 +195,7 @@ def launch(app, MW=None):
     # Code reference :
     # https://github.com/ipython/ipykernel/blob/master/examples/embedding/ipkernel_qtapp.py
     # https://github.com/ipython/ipykernel/blob/master/examples/embedding/internal_ipkernel.py
-    if len(sys.argv) > 1 and sys.argv[-1] == "--console":
+    if arguments.console:
         try:
             from IPython.lib.kernel import connect_qtconsole
             from ipykernel.kernelapp import IPKernelApp
@@ -241,18 +252,44 @@ def setup_signal_handlers(MW):
     signal.signal(signal.SIGTERM, sigint_handler("SIGTERM", MW))
 
 
+def process_commandline(argv):
+    import argparse
+    parser = argparse.ArgumentParser(description="Run the manuskript application.")
+    parser.add_argument("--console", help="open the IPython Jupyter QT Console as a debugging aid",
+                        action="store_true")
+    parser.add_argument("-v", "--verbose", action="count", default=1, help="lower the threshold for messages logged to the terminal")
+    parser.add_argument("-L", "--logfile", default=None, help="override the default log file location")
+    parser.add_argument("filename", nargs="?", metavar="FILENAME", help="the manuskript project (.msk) to open")
+
+    args = parser.parse_args(args=argv)
+
+    # Verbosity logic, see: https://gist.github.com/ms5/9f6df9c42a5f5435be0e
+    #args.verbose = 70 - (10*args.verbose) if args.verbose > 0 else 0
+
+    # Users cannot report what they do not notice: show CRITICAL, ERROR and WARNING always.
+    # Note that the default is set to 1, so account for that.
+    args.verbose = 40 - (10*args.verbose) if args.verbose > 0 else 0
+
+    return args
+
+
 def run():
     """
     Run separates prepare and launch for two reasons:
     1. I've read somewhere it helps with potential segfault (see comment below)
     2. So that prepare can be used in tests, without running the whole thing
     """
+    # Parse command-line arguments.
+    arguments = process_commandline(sys.argv)
+    # Initialize logging. (Does not include Qt integration yet.)
+    manuskript.logging.setUp(console_level=arguments.verbose)
+
     # Need to return and keep `app` otherwise it gets deleted.
-    app, MW = prepare()
+    app, MW = prepare(arguments)
     setup_signal_handlers(MW)
     # Separating launch to avoid segfault, so it seem.
     # Cf. http://stackoverflow.com/questions/12433491/is-this-pyqt-4-python-bug-or-wrongly-behaving-code
-    launch(app, MW)
+    launch(arguments, app, MW)
 
 
 if __name__ == "__main__":

--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -34,7 +34,7 @@ def prepare(arguments, tests=False):
     manuskript.logging.integrateQtLogging()
 
     # Log all the versions for less headaches.
-    manuskript.logging.logVersionInformation()
+    manuskript.logging.logRuntimeInformation()
 
     icon = QIcon()
     for i in [16, 32, 64, 128, 256, 512]:

--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -7,7 +7,6 @@ import sys
 import signal
 
 import manuskript.logging
-import manuskript.ui.views.webView
 from PyQt5.QtCore import QLocale, QTranslator, QSettings, Qt
 from PyQt5.QtGui import QIcon, QColor, QPalette
 from PyQt5.QtWidgets import QApplication, qApp, QStyleFactory
@@ -34,7 +33,9 @@ def prepare(arguments, tests=False):
     # Handle all sorts of Qt logging messages in Python.
     manuskript.logging.integrateQtLogging()
 
-    LOGGER.info("Running manuskript version {}.".format(getVersion()))
+    # Log all the versions for less headaches.
+    manuskript.logging.logVersionInformation()
+
     icon = QIcon()
     for i in [16, 32, 64, 128, 256, 512]:
         icon.addFile(appPath("icons/Manuskript/icon-{}px.png".format(i)))

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -639,7 +639,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.mdlCharacter.dataChanged.connect(self.startTimerNoChanges)
         self.mdlPlots.dataChanged.connect(self.startTimerNoChanges)
         self.mdlWorld.dataChanged.connect(self.startTimerNoChanges)
-        # self.mdlPersosInfos.dataChanged.connect(self.startTimerNoChanges)
         self.mdlStatus.dataChanged.connect(self.startTimerNoChanges)
         self.mdlLabels.dataChanged.connect(self.startTimerNoChanges)
 
@@ -664,9 +663,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         # Add project name to Window's name
         self.setWindowTitle(self.projectName() + " - " + self.tr("Manuskript"))
-
-        # Stuff
-        # self.checkPersosID()  # Shouldn't be necessary any longer
 
         # Show main Window
         self.switchToProject()
@@ -875,8 +871,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def loadEmptyDatas(self):
         self.mdlFlatData = QStandardItemModel(self)
         self.mdlCharacter = characterModel(self)
-        # self.mdlPersosProxy = persosProxyModel(self)
-        # self.mdlPersosInfos = QStandardItemModel(self)
         self.mdlLabels = QStandardItemModel(self)
         self.mdlStatus = QStandardItemModel(self)
         self.mdlPlots = plotModel(self)

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -38,6 +38,9 @@ from manuskript.ui.statusLabel import statusLabel
 from manuskript.ui.views.textEditView import textEditView
 from manuskript.functions import Spellchecker
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 class MainWindow(QMainWindow, Ui_MainWindow):
     # dictChanged = pyqtSignal(str)
 
@@ -584,7 +587,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         If ``loadFromFile`` is False, then it does not load datas from file.
         It assumes that the datas have been populated in a different way."""
         if loadFromFile and not os.path.exists(project):
-            print(self.tr("The file {} does not exist. Has it been moved or deleted?").format(project))
+            LOGGER.warning("The file {} does not exist. Has it been moved or deleted?".format(project))
             F.statusMessage(
                     self.tr("The file {} does not exist. Has it been moved or deleted?").format(project), importance=3)
             return
@@ -850,7 +853,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             # No UI feedback here as this code path indicates a race condition that happens
             # after the user has already closed the project through some way. But in that
             # scenario, this code should not be reachable to begin with.
-            print("Bug: there is no current project to save.")
+            LOGGER.error("There is no current project to save.")
             return
 
         r = loadSave.saveProject()  # version=0
@@ -861,12 +864,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
             feedback = self.tr("Project {} saved.").format(projectName)
             F.statusMessage(feedback, importance=0)
+            LOGGER.info("Project {} saved.".format(projectName))
         else:
             feedback = self.tr("WARNING: Project {} not saved.").format(projectName)
             F.statusMessage(feedback, importance=3)
-
-        # Giving some feedback in console
-        print(feedback)
+            LOGGER.warning("Project {} not saved.".format(projectName))
 
     def loadEmptyDatas(self):
         self.mdlFlatData = QStandardItemModel(self)
@@ -883,13 +885,13 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         # Giving some feedback
         if not errors:
-            print(self.tr("Project {} loaded.").format(project))
+            LOGGER.info("Project {} loaded.".format(project))
             F.statusMessage(
                     self.tr("Project {} loaded.").format(project), 2000)
         else:
-            print(self.tr("Project {} loaded with some errors:").format(project))
+            LOGGER.error("Project {} loaded with some errors:".format(project))
             for e in errors:
-                print(self.tr(" * {} wasn't found in project file.").format(e))
+                LOGGER.error(" * {} wasn't found in project file.".format(e))
             F.statusMessage(
                     self.tr("Project {} loaded with some errors.").format(project), 5000, importance = 3)
 
@@ -1525,7 +1527,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.menuView.addMenu(self.menuMode)
         self.menuView.addSeparator()
 
-        # print("Generating menus with", settings.viewSettings)
+        # LOGGER.debug("Generating menus with %s.", settings.viewSettings)
 
         for mnu, mnud, icon in menus:
             m = QMenu(mnu, self.menuView)
@@ -1619,7 +1621,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             warning2 = self.tr("PyQt {} and Qt {} are in use.").format(qVersion(), PYQT_VERSION_STR)
 
             # Don't translate for debug log.
-            print("WARNING:", warning1, warning2)
+            LOGGER.warning(warning1)
+            LOGGER.warning(warning2)
 
             msg = QMessageBox(QMessageBox.Warning,
                 self.tr("Proceed with import at your own risk"),

--- a/manuskript/models/abstractItem.py
+++ b/manuskript/models/abstractItem.py
@@ -13,6 +13,8 @@ import re
 
 from manuskript import enums
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class abstractItem():
 
@@ -209,7 +211,7 @@ class abstractItem():
         self.IDs = self.listAllIDs()
 
         if max([self.IDs.count(i) for i in self.IDs if i]) != 1:
-            print("WARNING ! There are some items with same IDs:", [i for i in self.IDs if i and self.IDs.count(i) != 1])
+            LOGGER.warning("There are some items with overlapping IDs: %s", [i for i in self.IDs if i and self.IDs.count(i) != 1])
 
         def checkChildren(item):
             for c in item.children():

--- a/manuskript/models/abstractModel.py
+++ b/manuskript/models/abstractModel.py
@@ -26,6 +26,8 @@ except:
     pass
 import time, os
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class abstractModel(QAbstractItemModel):
     """
@@ -74,7 +76,7 @@ class abstractModel(QAbstractItemModel):
         if len(parent.children()) == 0:
             return None
 
-        # print(item.title(), [i.title() for i in parent.children()])
+        #LOGGER.debug("%s: %s", item.title(), [i.title() for i in parent.children()])
 
         row = parent.children().index(item)
         col = column
@@ -168,7 +170,7 @@ class abstractModel(QAbstractItemModel):
 
             # self.dataChanged.emit(index.sibling(index.row(), 0),
             # index.sibling(index.row(), max([i.value for i in Outline])))
-            # print("Model emit", index.row(), index.column())
+            # LOGGER.debug("Model dataChanged emit: %s, %s", index.row(), index.column())
             self.dataChanged.emit(index, index)
 
             if index.column() == Outline.type:

--- a/manuskript/models/outlineItem.py
+++ b/manuskript/models/outlineItem.py
@@ -23,6 +23,8 @@ except:
     # number formatting
     pass
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class outlineItem(abstractItem, searchableItem):
 
@@ -382,7 +384,7 @@ class outlineItem(abstractItem, searchableItem):
                     searchIn = character.name()
                 else:
                     searchIn = ""
-                    print("Character POV not found:", self.POV())
+                    LOGGER.error("Character POV not found: %s", self.POV())
 
             elif c == self.enum.status:
                 searchIn = mainWindow.mdlStatus.item(F.toInt(self.status()), 0).text()

--- a/manuskript/models/references.py
+++ b/manuskript/models/references.py
@@ -3,6 +3,9 @@
 
 import re
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 ###############################################################################
 # SHORT REFERENCES
 ###############################################################################
@@ -627,7 +630,7 @@ def open(ref):
             mw.lstCharacters.setCurrentItem(item)
             return True
 
-        print("Error: Ref {} not found".format(ref))
+        LOGGER.error("Character reference {} not found.".format(ref))
         return False
 
     elif _type == TextLetter:
@@ -639,7 +642,7 @@ def open(ref):
             mw.mainEditor.setCurrentModelIndex(index, newTab=True)
             return True
         else:
-            print("Ref not found")
+            LOGGER.error("Text reference {} not found.".format(ref))
             return False
 
     elif _type == PlotLetter:
@@ -651,7 +654,7 @@ def open(ref):
             mw.lstPlots.setCurrentItem(item)
             return True
 
-        print("Ref not found")
+        LOGGER.error("Plot reference {} not found.".format(ref))
         return False
 
     elif _type == WorldLetter:
@@ -664,8 +667,8 @@ def open(ref):
                     mw.mdlWorld.indexFromItem(item))
             return True
 
-        print("Ref not found")
+        LOGGER.error("World reference {} not found.".format(ref))
         return False
 
-    print("Ref not implemented")
+    LOGGER.error("Unable to identify reference type: {}.".format(ref))
     return False

--- a/manuskript/settings.py
+++ b/manuskript/settings.py
@@ -8,6 +8,9 @@ from PyQt5.QtWidgets import qApp
 
 from manuskript.enums import Outline
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 # TODO: move some/all of those settings to application settings and not project settings
 #       in order to allow a shared project between several writers
 
@@ -187,7 +190,7 @@ def load(string, fromString=False, protocol=None):
             allSettings = pickle.load(f)
 
         except:
-            print("{} doesn't exist, cannot load settings.".format(string))
+            LOGGER.error("Cannot load settings, {} does not exist.".format(string))
             return
     else:
         if protocol == 0:

--- a/manuskript/tests/__init__.py
+++ b/manuskript/tests/__init__.py
@@ -13,7 +13,8 @@ QApplication([])
 
 # Create app and mainWindow
 from manuskript import main
-app, MW = main.prepare(tests=True)
+arguments = main.process_commandline([])
+app, MW = main.prepare(arguments, tests=True)
 
 # FIXME: Again, don't know why, but when closing a project and then reopening
 #        one, we get a `TypeError: connection is not unique` in MainWindow:

--- a/manuskript/ui/collapsibleGroupBox.py
+++ b/manuskript/ui/collapsibleGroupBox.py
@@ -6,6 +6,8 @@ from PyQt5.QtWidgets import QSizePolicy, QGroupBox, QWidget, QStylePainter, QSty
     QStyle, QStyleOptionFrame, QStyleOptionFocusRect
 from manuskript.ui import style as S
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class collapsibleGroupBox(QGroupBox):
     def __init__(self, parent=None):
@@ -25,7 +27,7 @@ class collapsibleGroupBox(QGroupBox):
             self.tempWidget.setLayout(self.layout())
             # Set empty layout
             l = QVBoxLayout()
-            # print(l.contentsMargins().left(), l.contentsMargins().bottom(), l.contentsMargins().top(), )
+            # LOGGER.debug("Bounds: %s, %s, %s, %s", l.contentsMargins().left(), l.contentsMargins().bottom(), l.contentsMargins().top(), l.contentsMargins().right())
             l.setContentsMargins(0, 0, 0, 0)
             self.setLayout(l)
             self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)

--- a/manuskript/ui/editors/MDFunctions.py
+++ b/manuskript/ui/editors/MDFunctions.py
@@ -6,6 +6,8 @@ import re
 from PyQt5.QtCore import QRegExp
 from PyQt5.QtGui import QTextCursor
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 def MDFormatSelection(editor, style):
     """
@@ -15,5 +17,5 @@ def MDFormatSelection(editor, style):
         1: italic
         2: code
     """
-    print("Formatting:", style, " (Unimplemented yet !)")
+    LOGGER.error("Formatting: %s (Not implemented!)", style)
     # FIXME

--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -19,6 +19,8 @@ from manuskript.ui.editors.themes import loadThemeDatas
 from manuskript.ui.views.MDEditView import MDEditView
 from manuskript.functions import Spellchecker
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class fullScreenEditor(QWidget):
     def __init__(self, index, parent=None, screenNumber=None):
@@ -177,7 +179,7 @@ class fullScreenEditor(QWidget):
         # self.show()
 
     def __del__(self):
-        # print("Leaving fullScreenEditor via Destructor event", flush=True)
+        LOGGER.debug("Leaving fullScreenEditor via Destructor event.")
         self.showNormal()
         self.close()
 
@@ -286,7 +288,7 @@ class fullScreenEditor(QWidget):
     def keyPressEvent(self, event):
         if event.key() in [Qt.Key_Escape, Qt.Key_F11] and \
                 not self._locked:
-            # print("Leaving fullScreenEditor via keyPressEvent", flush=True)
+            LOGGER.debug("Leaving fullScreenEditor via keyPressEvent.")
             self.showNormal()
             self.close()
         elif (event.modifiers() & Qt.AltModifier) and \

--- a/manuskript/ui/editors/mainEditor.py
+++ b/manuskript/ui/editors/mainEditor.py
@@ -20,6 +20,9 @@ try:
 except:
     pass
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 class mainEditor(QWidget, Ui_mainEditor):
     """
     `mainEditor` is responsible for opening `outlineItem`s and offering information
@@ -389,7 +392,6 @@ class mainEditor(QWidget, Ui_mainEditor):
     ###############################################################################
 
     def setDict(self, dict):
-        print(dict)
         for w in self.allAllTabs():
             w.setDict(dict)
 

--- a/manuskript/ui/editors/tabSplitter.py
+++ b/manuskript/ui/editors/tabSplitter.py
@@ -10,6 +10,8 @@ from manuskript.functions import mainWindow, appPath
 from manuskript.ui import style
 from manuskript.ui.editors.tabSplitter_ui import Ui_tabSplitter
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class tabSplitter(QWidget, Ui_tabSplitter):
     """
@@ -39,7 +41,7 @@ class tabSplitter(QWidget, Ui_tabSplitter):
         # try:
         #     self.tab.setTabBarAutoHide(True)
         # except AttributeError:
-        #     print("Info: install Qt 5.4 or higher to use tab bar auto-hide in editor.")
+        #     LOGGER.info("Install Qt 5.4 or higher to use tab bar auto-hide in editor.")
 
         # Button to split
         self.btnSplit = QPushButton(self)

--- a/manuskript/ui/highlighters/basicHighlighter.py
+++ b/manuskript/ui/highlighters/basicHighlighter.py
@@ -12,6 +12,8 @@ import manuskript.ui.style as S
 from manuskript import settings
 from manuskript import functions as F
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class BasicHighlighter(QSyntaxHighlighter):
     def __init__(self, editor):
@@ -130,14 +132,14 @@ class BasicHighlighter(QSyntaxHighlighter):
         before you do any custom highlighting. Or implement doHighlightBlock.
         """
 
-        #print(">", self.currentBlock().document().availableUndoSteps())
+        #LOGGER.debug("undoSteps before: %s", self.currentBlock().document().availableUndoSteps())
         c = QTextCursor(self.currentBlock())
         #c.joinPreviousEditBlock()
         bf = QTextBlockFormat(self._defaultBlockFormat)
         if bf != c.blockFormat():
             c.setBlockFormat(bf)
         #c.endEditBlock()
-        #print(" ", self.currentBlock().document().availableUndoSteps())
+        #LOGGER.debug("undoSteps after: %s", self.currentBlock().document().availableUndoSteps())
 
         # self.setFormat(0, len(text), self._defaultCharFormat)
 

--- a/manuskript/ui/highlighters/markdownTokenizer.py
+++ b/manuskript/ui/highlighters/markdownTokenizer.py
@@ -9,6 +9,9 @@ from PyQt5.QtWidgets import *
 from manuskript.ui.highlighters import MarkdownState as MS
 from manuskript.ui.highlighters import MarkdownTokenType as MTT
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 # This file is simply a python translation of GhostWriter's Tokenizer.
 # http://wereturtle.github.io/ghostwriter/
 # GPLV3+.
@@ -56,7 +59,7 @@ class HighlightTokenizer:
         self.tokens.append(token)
 
         if token.type == -1:
-            print("Error here", token.position, token.length)
+            LOGGER.error("Token type invalid: position %s, length %s.", token.position, token.length)
 
     def setState(self, state):
         self.state = state

--- a/manuskript/ui/views/MDEditView.py
+++ b/manuskript/ui/views/MDEditView.py
@@ -14,6 +14,8 @@ from manuskript.ui.highlighters.markdownEnums import MarkdownState as MS
 from manuskript.ui.highlighters.markdownTokenizer import MarkdownTokenizer as MT
 from manuskript import functions as F
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class MDEditView(textEditView):
 
@@ -660,10 +662,10 @@ class ImageTooltip:
             return
         else:
             # Somehow we lost track. Log what we can to hopefully figure it out.
-            print("Warning: unable to match fetched data for tooltip to original request.")
-            print("- Completed request:", url_key)
-            print("- Status upon finishing:", reply.error(), reply.errorString())
-            print("- Currently processing:", ImageTooltip.processing)
+            LOGGER.warning("Unable to match fetched data for tooltip to original request.")
+            LOGGER.warning("- Completed request: %s", url_key)
+            LOGGER.warning("- Status upon finishing: %s, %s", reply.error(), reply.errorString())
+            LOGGER.warning("- Currently processing: %s", ImageTooltip.processing)
             return
 
         # Update cache with retrieved data.

--- a/manuskript/ui/views/dndView.py
+++ b/manuskript/ui/views/dndView.py
@@ -13,7 +13,6 @@ class dndView(QAbstractItemView):
 
     def dragMoveEvent(self, event):
         # return QAbstractItemView.dragMoveEvent(self, event)
-        # print(a)
         if event.keyboardModifiers() & Qt.ControlModifier:
             event.setDropAction(Qt.CopyAction)
         else:

--- a/manuskript/ui/views/propertiesView.py
+++ b/manuskript/ui/views/propertiesView.py
@@ -7,6 +7,8 @@ from manuskript.enums import Outline
 from manuskript.ui.views.propertiesView_ui import Ui_propertiesView
 from manuskript.models.characterPOVModel import characterPOVModel
 
+import logging
+LOGGER = logging.getLogger(__name__)
 
 class propertiesView(QWidget, Ui_propertiesView):
     def __init__(self, parent=None):
@@ -39,7 +41,7 @@ class propertiesView(QWidget, Ui_propertiesView):
     def selectionChanged(self, sourceView):
 
         indexes = self.getIndexes(sourceView)
-        # print(indexes)
+        # LOGGER.debug("selectionChanged indexes: %s", indexes)
         if len(indexes) == 0:
             self.setEnabled(False)
 

--- a/manuskript/ui/views/textEditView.py
+++ b/manuskript/ui/views/textEditView.py
@@ -17,6 +17,9 @@ from manuskript.functions import Spellchecker
 from manuskript.models.characterModel import Character, CharacterInfo
 
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 class textEditView(QTextEdit):
     def __init__(self, parent=None, index=None, html=None, spellcheck=None,
                  highlighting=False, dict="", autoResize=False):
@@ -58,13 +61,13 @@ class textEditView(QTextEdit):
         self.updateTimer.setInterval(500)
         self.updateTimer.setSingleShot(True)
         self.updateTimer.timeout.connect(self.submit)
-        # self.updateTimer.timeout.connect(lambda: print("Timeout"))
+        # self.updateTimer.timeout.connect(lambda: LOGGER.debug("Timeout."))
 
         self.updateTimer.stop()
         self.document().contentsChanged.connect(self.updateTimer.start, F.AUC)
-        # self.document().contentsChanged.connect(lambda: print("Document changed"))
+        # self.document().contentsChanged.connect(lambda: LOGGER.debug("Document changed."))
 
-        # self.document().contentsChanged.connect(lambda: print(self.objectName(), "Contents changed"))
+        # self.document().contentsChanged.connect(lambda: LOGGER.debug("Contents changed: %s", self.objectName()))
 
         self.setEnabled(False)
 
@@ -248,7 +251,7 @@ class textEditView(QTextEdit):
             if topLeft.parent() != self._index.parent():
                 return
 
-                # print("Model changed: ({}:{}), ({}:{}/{}), ({}:{}) for {} of {}".format(
+                # LOGGER.debug("Model changed: ({}:{}), ({}:{}/{}), ({}:{}) for {} of {}".format(
                 # topLeft.row(), topLeft.column(),
                 # self._index.row(), self._index.row(), self._column,
                 # bottomRight.row(), bottomRight.column(),
@@ -278,11 +281,11 @@ class textEditView(QTextEdit):
     def updateText(self):
         self._updating.lock()
 
-        # print("Updating", self.objectName())
+        # LOGGER.debug("Updating %s", self.objectName())
         if self._index:
             self.disconnectDocument()
             if self.toPlainText() != F.toString(self._index.data()):
-                # print("    Updating plaintext")
+                # LOGGER.debug("    Updating plaintext")
                 self.document().setPlainText(F.toString(self._index.data()))
             self.reconnectDocument()
 
@@ -319,18 +322,18 @@ class textEditView(QTextEdit):
         text = self.toPlainText()
         self._updating.unlock()
 
-        # print("Submitting", self.objectName())
+        # LOGGER.debug("Submitting %s", self.objectName())
         if self._index and self._index.isValid():
             # item = self._index.internalPointer()
             if text != self._index.data():
-                # print("    Submitting plain text")
+                # LOGGER.debug("    Submitting plain text")
                 self._model.setData(QModelIndex(self._index), text)
 
         elif self._indexes:
             for i in self._indexes:
                 item = i.internalPointer()
                 if text != F.toString(item.data(self._column)):
-                    print("Submitting many indexes")
+                    LOGGER.debug("Submitting many indexes")
                     self._model.setData(i, text)
 
     def keyPressEvent(self, event):
@@ -484,7 +487,7 @@ class textEditView(QTextEdit):
 
     def newCharacter(self):
         text = self.sender().data()
-        print("new character!", text)
+        LOGGER.debug(f'New character: {text}')
         # switch to character page
         mw = F.mainWindow()
         mw.tabMain.setCurrentIndex(mw.TabPersos)
@@ -496,7 +499,7 @@ class textEditView(QTextEdit):
 
     def newPlotItem(self):
         text = self.sender().data()
-        print("new plot item!", text)
+        LOGGER.debug(f'New plot item: {text}')
         # switch to plot page
         mw = F.mainWindow()
         mw.tabMain.setCurrentIndex(mw.TabPlots)
@@ -509,7 +512,7 @@ class textEditView(QTextEdit):
 
     def newWorldItem(self):
         text = self.sender().data()
-        print("new world item!", text)
+        LOGGER.debug(f'New world item: {text}')
         mw = F.mainWindow()
         mw.tabMain.setCurrentIndex(mw.TabWorld)
         item = mw.mdlWorld.addItem(title=text)

--- a/manuskript/ui/views/webView.py
+++ b/manuskript/ui/views/webView.py
@@ -22,16 +22,13 @@ else:
 
 if features['qtwebkit']:
     from PyQt5.QtWebKitWidgets import QWebView
-    print("Debug: Web rendering engine used: QWebView")
     webEngine = "QtWebKit"
     webView = QWebView
 elif features['qtwebengine']:
     from PyQt5 import QtWebEngineWidgets
-    print("Debug: Web rendering engine used: QWebEngineView")
     webEngine = "QtWebEngine"
     webView = QtWebEngineWidgets.QWebEngineView
 else:
     from PyQt5.QtWidgets import QTextEdit
-    print("Debug: Web rendering engine used: QTextEdit")
     webEngine = "QTextEdit"
     webView = QTextEdit

--- a/manuskript/ui/welcome.py
+++ b/manuskript/ui/welcome.py
@@ -21,6 +21,9 @@ from manuskript.models.worldModel import worldModel
 from manuskript.ui.welcome_ui import Ui_welcome
 from manuskript.ui import style as S
 
+import logging
+LOGGER = logging.getLogger(__name__)
+
 try:
     locale.setlocale(locale.LC_ALL, '')
 except:
@@ -57,8 +60,7 @@ class welcome(QWidget, Ui_welcome):
         sttgs = QSettings()
         lastDirectory = sttgs.value("lastAccessedDirectory", defaultValue=".", type=str)
         if lastDirectory != '.':
-            print(qApp.translate("lastAccessedDirectoryInfo", "Last accessed directory \"{}\" loaded.").format(
-                lastDirectory))
+            LOGGER.info("Last accessed directory \"{}\" loaded.".format(lastDirectory))
         return lastDirectory
 
     def setLastAccessedDirectory(self, dir):

--- a/manuskript/ui/welcome.py
+++ b/manuskript/ui/welcome.py
@@ -422,10 +422,12 @@ class welcome(QWidget, Ui_welcome):
         self.tree.expandAll()
 
     def loadDefaultDatas(self):
+        """Initialize a basic Manuskript project."""
 
         # Empty settings
         imp.reload(settings)
         settings.initDefaultValues()
+        self.mw.loadEmptyDatas()
 
         if self.template:
             t = [i for i in self._templates if i[0] == self.template[0]]
@@ -433,20 +435,10 @@ class welcome(QWidget, Ui_welcome):
                 settings.viewMode = "simple"
 
         # Tasks
-        self.mw.mdlFlatData = QStandardItemModel(2, 8, self.mw)
-
-        # Persos
-        # self.mw.mdlPersos = QStandardItemModel(0, 0, self.mw)
-        self.mw.mdlCharacter = characterModel(self.mw)
-        # self.mdlPersosProxy = None # persosProxyModel() # None
-        # self.mw.mdlPersosProxy = persosProxyModel(self.mw)
-
-        # self.mw.mdlPersosInfos = QStandardItemModel(1, 0, self.mw)
-        # self.mw.mdlPersosInfos.insertColumn(0, [QStandardItem("ID")])
-        # self.mw.mdlPersosInfos.setHorizontalHeaderLabels(["Description"])
+        self.mw.mdlFlatData.setRowCount(2)     # data from: infos.txt, summary.txt
+        self.mw.mdlFlatData.setColumnCount(8)  # version_1.py: len(infos.txt) == 8
 
         # Labels
-        self.mw.mdlLabels = QStandardItemModel(self.mw)
         for color, text in [
             (Qt.transparent, ""),
             (Qt.yellow, self.tr("Idea")),
@@ -458,7 +450,6 @@ class welcome(QWidget, Ui_welcome):
             self.mw.mdlLabels.appendRow(QStandardItem(iconFromColor(color), text))
 
         # Status
-        self.mw.mdlStatus = QStandardItemModel(self.mw)
         for text in [
             "",
             self.tr("TODO"),
@@ -468,14 +459,9 @@ class welcome(QWidget, Ui_welcome):
         ]:
             self.mw.mdlStatus.appendRow(QStandardItem(text))
 
-        # Plot
-        self.mw.mdlPlots = plotModel(self.mw)
+        # Plot (nothing special needed)
 
         # Outline
-        self.mw.mdlOutline = outlineModel(self.mw)
-
-        # World
-        self.mw.mdlWorld = worldModel(self.mw)
 
         root = self.mw.mdlOutline.rootItem
         _type = "md"
@@ -509,3 +495,5 @@ class welcome(QWidget, Ui_welcome):
 
         if self.template and self.template[1]:
             addElement(root, self.template[1])
+
+        # World (nothing special needed)


### PR DESCRIPTION
I originally intended to work on something else, but in the process of wanting to make that happen I needed to improve the logging and the way command-line arguments are handled. And by the time I completed those, I realized my original intention might be a bit more thorny than anticipated. But since these improvements are enough of a change to merit a PR, here it is.

At its core, these changes embrace the Python `logging` and `argparse` modules, and aim to improve life for maintainers, contributors and everyone inbetween.

## Features

- Manuskript now logs to a file in addition to the console.; Default location: `{datadir}/manuskript.log`
  - Due to spammy Qt considerations, the log is wiped every time Manuskript starts. *I reached a >1mb file during some of my initial testing runs where all I did was start manuskript.*

  - Using **-L** / **--logfile** switch allows one to override to a more convenient location.

- We now support different severity levels of logging.

  - Stderr receives severity + message for WARNING+.

    - Consequence: no more useless spam on console when all goes well! Huzzah!

    - More detailed logs on console can be enabled through the **-v** / **--verbose** flag.

      - 1x lowers to INFO level, 2x lowers to DEBUG level.

      - Does not affect log file contents.

  - Log file receives timestamp, category, severity and message for all log levels.

- Every log message has an associated category, making it easier to contextualize program flow.

- Qt messages are also redirected through the new logging system.

- Comprehensive logging of all software versions.

  - If run from a git repository, it also logs the revision

    - This is to minimize the back-and-forth while responding to issues. *'Are you on the latest commit of develop?'* is a common-enough question. This allows testers to use the exact version affected without having to ask. (Assuming a log file was posted...)

- Various small adjustments.
  - Most intend to make the logs more readable.
  - The model-refactoring one is because I got really confused due to code duplication, and it just happened to be in my tree still. It is a pretty simple improvement so I decided to just let it be.

## Examples

### Argparse syntax

```
C:\Portable\Manuskript>py bin\manuskript -h
usage: manuskript [-h] [--console] [-v] [-L LOGFILE] [FILENAME]

Run the manuskript application.

positional arguments:
  FILENAME              the manuskript project (.msk) to open

optional arguments:
  -h, --help            show this help message and exit
  --console             open the IPython Jupyter QT Console as a debugging aid
  -v, --verbose         lower the threshold for messages logged to the
                        terminal
  -L LOGFILE, --logfile LOGFILE
                        override the default log file location
```

### [Sample manuskript.log](https://github.com/olivierkes/manuskript/files/3730492/manuskript.log)

## Code considerations

All source files that do logging should have this at the top:
```
import logging
LOGGER = logging.getLogger(__name__)
```
*'Why `LOGGER` in uppercase?'* you might ask. Simply because I found myself writing or even auto-completing to `logging` instead of `logger` on several occasions.

Since the `logging` module has convenience functions to log to the root namespace, that means we silently lose the category for context and any special handling. Using uppercase LOGGER appears like a nice tradeoff: it should not be changed by any code and it stands out visually so that it is easy to spot any mistakes during code reviews. (Since I went through the trouble of implementing all of the logging system, I might as well take some effort to make it harder to use it wrongly in the future...)

## Your input is required

- This PR needs testing on:
  * Windows XP (I still haven't set up a good VM for it, sorry!)
  * Linux
  * Mac
- Please do not limit your testing of new functionality to a `git pull`.
  Assuming it works fine, **please prepare actual test packages / releases** and test that, too.
  *This is due to some path sniffing code to make the Github revision search work, as well as making sure the log file can feasibly be stored wherever it ends up being dumped in those situations.*
- Please post sample log files for every platform so I can make sure the output is as expected.

Admission: I haven't tested against old Qt versions quite yet, so please don't merge blindly. I have tried to take care to not shortcomings in old versions, but you never know.

## Not happy with something? Have a suggestion? Let me know!

It is a lot of new code, and I mostly went with what seemed intuitive to me. I submitted this PR relatively early so that any breaking changes won't ruin many hours of testing. 😄 