### PR TITLE
Fixed translation mistake. Trilogy translates to Trilogie in German

### DIFF
--- a/i18n/manuskript_de.ts
+++ b/i18n/manuskript_de.ts
@@ -4275,7 +4275,7 @@ Nutze das, wenn du YAML-Errors bekommst.</translation>
     <message>
         <location filename="../manuskript/ui/welcome.py" line="238"/>
         <source>Trilogy</source>
-        <translation>Triologie</translation>
+        <translation>Trilogie</translation>
     </message>
     <message>
         <location filename="../manuskript/ui/welcome.py" line="238"/>


### PR DESCRIPTION
Menu item for "Trilogy" read "Triologie" in assistant for new project. Should be "Trilogie"