### PR TITLE
Fixed bugs caused by parallel access during multithreading

### DIFF
--- a/manuskript/ui/views/lineEditView.py
+++ b/manuskript/ui/views/lineEditView.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # --!-- coding: utf8 --!--
+from PyQt5.QtCore import QMutex
 from PyQt5.QtWidgets import QLineEdit
 
 from manuskript.enums import Outline
@@ -13,7 +14,7 @@ class lineEditView(QLineEdit):
         self._indexes = None
         self._index = None
         self._placeholderText = None
-        self._updating = False
+        self._updating = QMutex()
 
     def setModel(self, model):
         self._model = model
@@ -49,38 +50,39 @@ class lineEditView(QLineEdit):
         self.updateText()
 
     def submit(self):
+        self._updating.lock()
+        text = self.text()
+        self._updating.unlock()
+
         if self._index:
             # item = self._index.internalPointer()
-            if self.text() != self._model.data(self._index):
-                self._model.setData(self._index, self.text())
+            if text != self._model.data(self._index):
+                self._model.setData(self._index, text)
 
         elif self._indexes:
-            self._updating = True
             for i in self._indexes:
                 # item = i.internalPointer()
-                if self.text() != self._model.data(i):
-                    self._model.setData(i, self.text())
-            self._updating = False
+                if text != self._model.data(i):
+                    self._model.setData(i, text)
 
     def update(self, topLeft, bottomRight):
-
-        if self._updating:
-            # We are currently putting data in the model, so no updates
-            return
+        update = False
 
         if self._index:
             if topLeft.row() <= self._index.row() <= bottomRight.row():
-                self.updateText()
+                update = True
 
         elif self._indexes:
-            update = False
             for i in self._indexes:
                 if topLeft.row() <= i.row() <= bottomRight.row():
                     update = True
-            if update:
-                self.updateText()
+
+        if update:
+            self.updateText()
 
     def updateText(self):
+        self._updating.lock()
+
         if self._index:
             # item = self._index.internalPointer()
             # txt = toString(item.data(self._column))
@@ -110,3 +112,6 @@ class lineEditView(QLineEdit):
                     self._placeholderText = self.placeholderText()
 
                 self.setPlaceholderText(self.tr("Various"))
+
+        self._updating.unlock()
+

--- a/manuskript/ui/views/textEditView.py
+++ b/manuskript/ui/views/textEditView.py
@@ -3,7 +3,7 @@
 import re
 
 from PyQt5.Qt import QApplication
-from PyQt5.QtCore import QTimer, QModelIndex, Qt, QEvent, pyqtSignal, QRegExp, QLocale, QPersistentModelIndex
+from PyQt5.QtCore import QTimer, QModelIndex, Qt, QEvent, pyqtSignal, QRegExp, QLocale, QPersistentModelIndex, QMutex
 from PyQt5.QtGui import QTextBlockFormat, QTextCharFormat, QFont, QColor, QIcon, QMouseEvent, QTextCursor
 from PyQt5.QtWidgets import QWidget, QTextEdit, qApp, QAction, QMenu
 
@@ -24,7 +24,7 @@ class textEditView(QTextEdit):
         self._indexes = None
         self._model = None
         self._placeholderText = self.placeholderText()
-        self._updating = False
+        self._updating = QMutex()
         self._item = None
         self._highlighting = highlighting
         self._textFormat = "text"
@@ -237,11 +237,9 @@ class textEditView(QTextEdit):
             self.highlighter.setDefaultBlockFormat(self._defaultBlockFormat)
 
     def update(self, topLeft, bottomRight):
-        if self._updating:
-            return
+        update = False
 
         if self._index and self._index.isValid():
-
             if topLeft.parent() != self._index.parent():
                 return
 
@@ -253,15 +251,15 @@ class textEditView(QTextEdit):
 
             if topLeft.row() <= self._index.row() <= bottomRight.row():
                 if topLeft.column() <= self._column <= bottomRight.column():
-                    self.updateText()
+                    update = True
 
         elif self._indexes:
-            update = False
             for i in self._indexes:
                 if topLeft.row() <= i.row() <= bottomRight.row():
                     update = True
-            if update:
-                self.updateText()
+
+        if update:
+            self.updateText()
 
     def disconnectDocument(self):
         try:
@@ -273,10 +271,9 @@ class textEditView(QTextEdit):
         self.document().contentsChanged.connect(self.updateTimer.start, F.AUC)
 
     def updateText(self):
-        if self._updating:
-            return
+        self._updating.lock()
+
         # print("Updating", self.objectName())
-        self._updating = True
         if self._index:
             self.disconnectDocument()
             if self.toPlainText() != F.toString(self._index.data()):
@@ -307,30 +304,29 @@ class textEditView(QTextEdit):
 
                 self.setPlaceholderText(self.tr("Various"))
             self.reconnectDocument()
-        self._updating = False
+
+        self._updating.unlock()
 
     def submit(self):
         self.updateTimer.stop()
-        if self._updating:
-            return
+
+        self._updating.lock()
+        text = self.toPlainText()
+        self._updating.unlock()
+
         # print("Submitting", self.objectName())
         if self._index and self._index.isValid():
             # item = self._index.internalPointer()
-            if self.toPlainText() != self._index.data():
+            if text != self._index.data():
                 # print("    Submitting plain text")
-                self._updating = True
-                self._model.setData(QModelIndex(self._index),
-                                    self.toPlainText())
-                self._updating = False
+                self._model.setData(QModelIndex(self._index), text)
 
         elif self._indexes:
-            self._updating = True
             for i in self._indexes:
                 item = i.internalPointer()
-                if self.toPlainText() != F.toString(item.data(self._column)):
+                if text != F.toString(item.data(self._column)):
                     print("Submitting many indexes")
-                    self._model.setData(i, self.toPlainText())
-            self._updating = False
+                    self._model.setData(i, text)
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_V and event.modifiers() & Qt.ControlModifier:


### PR DESCRIPTION
Now the 'textEditView' should synchronize model and text thread safe without problems. The QMutex solves the causes of parallel access. I guess most people haven't got any problems because it is so rare. If I find similar pieces of code I will probably add Mutexes too.

Keep up the good work on this project!

Also here is some information I looked up to get the implementation right:
https://doc.qt.io/qtforpython/PySide2/QtCore/QMutex.html

Squashed version from here:
https://github.com/olivierkes/manuskript/pull/704