### PR TITLE
Remove support for macOS X Sierra (10.12) in Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 os:
 - osx
 - linux
-osx_image: xcode8.3
+osx_image: xcode10.1
 sudo: required
 install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then package/prepare_osx.sh; fi


### PR DESCRIPTION
The Travis CI builds for macOS X are failing because there are no
Homebrew bottles (packages) for macOS X Sierra (10.12).

The error message in the Travis CI log is:

    ...
    # Upgrade to python 3.x
    brew upgrade python
    Warning: You are using macOS 10.12.
    We (and Apple) do not provide support for this old version.
    ...

Note that by default the Travis CI will terminate a build after 10
minutes if no output has been received.  Unfortunately building qt
from source code may take hours, so installation using a Homebrew
bottle is required.

To address this issue, choose a macOS X version that has a Homebrew
bottle for qt [1].

[1] https://formulae.brew.sh/formula/qt

The homebrew project currently lists having a qt bottle for:

  - Catalina (10.15)
  - Mojave (10.14)
  - High Sierra (10.13)

No bottle is listed for macOS Sierra (10.12)

In order to support as many versions of macOS X as possible, choose
the lowest osx_image value [2] that is currently supported with a
homebrew bottle.

[2] https://docs.travis-ci.com/user/reference/osx#os-x-version

At this time osx_image value xcode9.3 is listed as supporting OS X
10.13.

Unfortunately xcode9.3 did not work in the Travis CI build.

By following the suggestions for troubleshooting homebrew [3] a
discovery was made that a higher value of xcode10.1 was required.

[3] https://docs.brew.sh/Troubleshooting

Suggestion was to use "brew update" twice and "brew doctor" twice.

The messages in the log were as follows:

    ...
    Warning: Your Xcode (9.3) is outdated.
    Please update to Xcode 10.1 (or delete it).
    ...

Now try setting osx_image value to xcode10.1 which is listed as
supporting OS X 10.13.

**NOTE**:  While this PR does not succeed in creating a new macOS X PyInstaller package, it does address the issue of Apple and Homebrew dropping support for macOS X Sierra (10.12).  As such I plan to merge this PR.

The problem with the failure to create a macOS X PyInstaller package requires a macOS X person to investigate and fix.