### PR TITLE
Change wording of import warning for PyQt/Qt versions 5.11 and 5.12

### DIFF
--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -1596,7 +1596,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             print("WARNING:", warning1, warning2)
 
             msg = QMessageBox(QMessageBox.Warning,
-                self.tr("Proceeding might crash and lose data"),
+                self.tr("Proceed with import at your own risk"),
                 "<p><b>" +
                     warning1 +
                 "</b></p>" +


### PR DESCRIPTION
Two separate pull requests indicate an issue translating the warning
for when an import is attempted with PyQt/Qt versions 5.11 and 5.12.
As such change the warning message.

See PRs #668 and #701.

Following is a screen shot of the warning message when run on Ubuntu 18.10.

![Manuskript-Import-Warning-Dialog](https://user-images.githubusercontent.com/10405019/72092446-863d3a00-32cf-11ea-9f08-1c827ecd05d9.png)
