### PR TITLE
Select newly added world items, opening branches as necessary

### DIFF
--- a/manuskript/models/worldModel.py
+++ b/manuskript/models/worldModel.py
@@ -136,6 +136,9 @@ class worldModel(QStandardItemModel):
         _id = QStandardItem(self.getUniqueID())
         row = [name, _id] + [QStandardItem() for i in range(2, len(World))]
         parent.appendRow(row)
+
+        self.mw.treeWorld.setExpanded(self.selectedIndex(), True)
+        self.mw.treeWorld.setCurrentIndex(self.indexFromItem(name))
         return name
 
     def getUniqueID(self):


### PR DESCRIPTION
It was unclear that I was adding child items to closed branches in the World tree view, and this should not only show the new item in the tree, but select it for immediate editing.