### PR TITLE
Add snap layout for pandoc templates directory

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,9 @@ grade: stable
 confinement: strict
 base: core18
 icon: icons/Manuskript/manuskript.svg
+layout:
+  /usr/share/pandoc/data/templates:
+    bind: $SNAP/usr/share/pandoc/data/templates
 
 apps:
   manuskript:


### PR DESCRIPTION
pandoc is installed via apt into the snap, but we need the files that are installed to be available in the context that the snap is running in.
This uses the snap layouts feature to map the installed directory into the context filesystem.

Fixes https://github.com/olivierkes/manuskript/issues/709