### PR TITLE
Set minimum of xcode11 for macOS X in Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 os:
 - osx
 - linux
-osx_image: xcode10.1
+osx_image: xcode11
 sudo: required
 install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then package/prepare_osx.sh; fi


### PR DESCRIPTION
The Travis CI builds for macOS X are failing for xcode values less than 11.

Reference information for macOS X:

- Homebrew project bottles for qt
  https://formulae.brew.sh/formula/qt

- Travis CI build values for xcode
  https://docs.travis-ci.com/user/reference/osx#macos-version

See also related issue:

- Issue #696 - Install on Mac Catalina Requires Signed Installer