### PR TITLE
Fix Python 3.8 SyntaxWarning: "is not" with a literal

### DIFF
--- a/manuskript/exporter/pandoc/abstractPlainText.py
+++ b/manuskript/exporter/pandoc/abstractPlainText.py
@@ -75,7 +75,7 @@ class pandocSetting:
         """Return whether the specific setting is active with the given format."""
 
         # Empty formats means all
-        if self.formats is "":
+        if self.formats == "":
             return True
 
         # "html" in "html markdown latex"

--- a/manuskript/importer/opmlImporter.py
+++ b/manuskript/importer/opmlImporter.py
@@ -121,4 +121,4 @@ class opmlImporter(abstractImporter):
         s = cls.restoreNewLines(inString)
         s = ''.join(s.split())
 
-        return len(s) is 0
+        return len(s) == 0

--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -101,7 +101,7 @@ def prepare(tests=False):
 
     def respectSystemDarkThemeSetting():
         """Adjusts the Qt theme to match the OS 'dark theme' setting configured by the user."""
-        if platform.system() is not 'Windows':
+        if platform.system() != 'Windows':
             return
 
         # Basic Windows 10 Dark Theme support.


### PR DESCRIPTION
Recently some SyntaxWarning messages that arise from Python 3.8 were brought to light with issue #758.

Fix these three warning messages from Python 3.8:

```
/usr/share/manuskript/manuskript/main.py:104: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if platform.system() is not 'Windows':

/usr/share/manuskript/manuskript/importer/opmlImporter.py:124: SyntaxWarning: "is" with a literal. Did you mean "=="?
  return len(s) is 0

/usr/share/manuskript/manuskript/exporter/pandoc/abstractPlainText.py:78: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self.formats is "":
```

See also:

  Issue34850 - Emit a syntax warning for "is" with a literal
  https://bugs.python.org/issue34850

This PR is part of an ongoing effort to fix bugs in Manuskript.