### PR TITLE
Update abstractModel.py

### DIFF
--- a/manuskript/models/abstractModel.py
+++ b/manuskript/models/abstractModel.py
@@ -36,6 +36,9 @@ class abstractModel(QAbstractItemModel):
     - Interface with QModelIndex and stuff
     - XML Import / Export
     - Drag'n'drop
+    
+    Row => item/abstractModel/etc.
+    Col => data sub-element. Col 1 (second counting) is ID for all model types.
 
     """
     def __init__(self, parent):
@@ -415,21 +418,32 @@ class abstractModel(QAbstractItemModel):
         # In case of copy actions, items might be duplicates, so we need new IDs.
         # But they might not be, if we cut, then paste. Paste is a Copy Action.
         # The first paste would not need new IDs. But subsequent ones will.
+        
+        # Recursively change the existing IDs to new, unique values. No need to strip out the old
+        # even if they are not duplicated in pasting. There is no practical need for ID conservation.
+
         if action == Qt.CopyAction:
             IDs = self.rootItem.listAllIDs()
-
+            
             for item in items:
                 if item.ID() in IDs:
-                    # Recursively remove ID. So will get a new one when inserted.
-                    def stripID(item):
-                        item.setData(Outline.ID, None)
-                        for c in item.children():
-                            stripID(c)
-
-                    stripID(item)
-
+                    def makeNewID(item):    
+                        k = 1
+                        while True: # Python doesn't have "Do...While"
+                            ks = str(k)
+                            if ks not in IDs:
+                                item.setData(Outline.ID,ks)
+                                IDs.append(ks) #Keep track of new IDs allocated.
+                                for c in item.children():
+                                    makeNewID(c)
+                                break # Actual Loop Exit
+                            else:
+                                k = k+1 # Try the next candidate ID
+                                
+                    makeNewID(item)       
         r = self.insertItems(items, beginRow, parent)
-
+        
+        
         return r
 
     ################# ADDING AND REMOVING #################
@@ -448,13 +462,13 @@ class abstractModel(QAbstractItemModel):
 
         # Insert only if parent is folder
         if parentItem.isFolder():
-            self.beginInsertRows(parent, row, row + len(items) - 1)
-
+            self.beginInsertRows(parent, row, row + len(items) - 1) # Create space.
+            
             for i in items:
                 parentItem.insertChild(row + items.index(i), i)
-
+            
             self.endInsertRows()
-
+            
             return True
 
         else:
@@ -507,8 +521,9 @@ class abstractModel(QAbstractItemModel):
         else:
             parentItem = parent.internalPointer()
 
-        self._removingRows = True  # Views that are updating can easily know
-                                   # if this is due to row removal.
+        self._removingRows = True 
+        # Views that are updating can easily know
+        # if this is due to row removal.
         self.beginRemoveRows(parent, row, row + count - 1)
         for i in range(count):
             item = parentItem.removeChild(row)


### PR DESCRIPTION
Corrected code which deleted IDs, but did not assure new unique ID values which in complex copy paste operations would result in items in the Outline list that had no IDs. Replacing instead of deleting and replacing insures no escapes.