### PR TITLE
Don't arbitrarily delete extra files in project folder

### DIFF
--- a/manuskript/load_save/version_1.py
+++ b/manuskript/load_save/version_1.py
@@ -391,14 +391,6 @@ def saveProject(zip=None):
 
         # Removing phantoms
         for path in [p for p in cache if p not in [p for p, c in files]]:
-            filename = os.path.join(dir, folder, path)
-            log("* Removing", path)
-
-            if os.path.isdir(filename):
-                shutil.rmtree(filename)
-
-            else:  # elif os.path.exists(filename)
-                os.remove(filename)
 
             # Clear cache
             cache.pop(path, 0)


### PR DESCRIPTION
Currently, the program deletes any files that it doesn't recognize in your project folder. Perhaps useful for deleting "orphan" files, but if you store things like custom pandoc YAML files and various peripheral files in that folder, then it seems rather destructive to always be arbitrarily deleting files like these.