### PR TITLE
Fixed pandoc command arguments

### DIFF
--- a/manuskript/exporter/pandoc/abstractPlainText.py
+++ b/manuskript/exporter/pandoc/abstractPlainText.py
@@ -110,7 +110,7 @@ class pandocSettings(markdownSettings):
                                       qApp.translate("Export", "Normalize the document (cleaner)")),
         "base-header":  pandocSetting("--shift-heading-level-by=", "number", "",
                                       qApp.translate("Export", "Specify the base level for headers: "),
-                                      default=1, min=1),
+                                      default=0, min=0),
         "disable-YAML": pandocSetting("EXT-yaml_metadata_block", "checkbox", "",
                                       qApp.translate("Export", "Disable YAML metadata block.\nUse that if you get YAML related error.")),
 

--- a/manuskript/exporter/pandoc/abstractPlainText.py
+++ b/manuskript/exporter/pandoc/abstractPlainText.py
@@ -108,7 +108,7 @@ class pandocSettings(markdownSettings):
         # pandoc v1 only
         "normalize":    pandocSetting("--normalize", "checkbox", "",
                                       qApp.translate("Export", "Normalize the document (cleaner)")),
-        "base-header":  pandocSetting("--base-header-level=", "number", "",
+        "base-header":  pandocSetting("--shift-heading-level-by=", "number", "",
                                       qApp.translate("Export", "Specify the base level for headers: "),
                                       default=1, min=1),
         "disable-YAML": pandocSetting("EXT-yaml_metadata_block", "checkbox", "",


### PR DESCRIPTION
`--base-header-level` throws a new export error because it is deprecated, now we should use `--shift-heading-level-by`