### PR TITLE
Fix for TypeErrors when using certain app styles

### DIFF
--- a/manuskript/ui/views/outlineDelegates.py
+++ b/manuskript/ui/views/outlineDelegates.py
@@ -313,7 +313,7 @@ class outlineLabelDelegate(QStyledItemDelegate):
         idx = self.mdlLabels.indexFromItem(item)
         opt = QStyleOptionViewItem(option)
         self.initStyleOption(opt, idx)
-        s = qApp.style().sizeFromContents(QStyle.CT_ItemViewItem, opt, QSize())
+        s = qApp.style().sizeFromContents(QStyle.CT_ItemViewItem, opt, QSize(), None)
         if s.width() > 150:
             s.setWidth(150)
         elif s.width() < 50:

--- a/manuskript/ui/views/treeDelegates.py
+++ b/manuskript/ui/views/treeDelegates.py
@@ -34,8 +34,8 @@ class treeTitleDelegate(QStyledItemDelegate):
         opt = QStyleOptionViewItem(option)
         self.initStyleOption(opt, index)
 
-        iconRect = style.subElementRect(style.SE_ItemViewItemDecoration, opt)
-        textRect = style.subElementRect(style.SE_ItemViewItemText, opt)
+        iconRect = style.subElementRect(style.SE_ItemViewItemDecoration, opt, None)
+        textRect = style.subElementRect(style.SE_ItemViewItemText, opt, None)
 
         # Background
         style.drawPrimitive(style.PE_PanelItemViewItem, opt, painter)


### PR DESCRIPTION
When i was using certain app styles like _cleanlooks_ or _qt5ct-style_, a TypeError was raising in cascade about the function not having enough arguments.
It seemed that, despite the last args of `Qstyle.subElementRect()` and `Qstyle.sizeFromContents()` were optional, it was still required to add it (even if it was just `None` in these cases).
That TypeError was only appearing with certain styles, at startup or when changing styles in the settings window.

![bug_style1](https://user-images.githubusercontent.com/12914480/90167280-c996e400-dd9b-11ea-9965-8660d7568ede.png)
![bug_style2](https://user-images.githubusercontent.com/12914480/90167315-d287b580-dd9b-11ea-8943-c8079553266e.png)
