### PR TITLE
Fixed project not opening with missing background

### DIFF
--- a/manuskript/ui/views/corkView.py
+++ b/manuskript/ui/views/corkView.py
@@ -27,6 +27,8 @@ class corkView(QListView, dndView, outlineBasics):
     def updateBackground(self):
         if settings.corkBackground["image"] != "":
             img = findBackground(settings.corkBackground["image"])
+            if img == None:
+                img = ""
         else:
             # No background image
             img = ""


### PR DESCRIPTION
This should fix Issue #786 where Manuskript project files wouldn't open if the custom corkboard image was missing. The problem is that findFirstFile returns None if it doesn't find a file, so I added a check to see if the image was None to prevent it from trying to open a resource which doesn't exist. This is the quick way to patch this. I'd recommend changing the findFirstFile function in functions/__init__.py for a more permanent solution, but I don't know the knock-on effects of that, so this should suffice for now. Another suggestion could be to bundle custom image resources in the project file. Or, throw in some error handling.