### PR TITLE
Fix #456 - Force the distraction free window on the display of the main window

### DIFF
--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -6,7 +6,7 @@ from PyQt5.QtCore import Qt, QSize, QPoint, QRect, QEvent, QTime, QTimer
 from PyQt5.QtGui import QFontMetrics, QColor, QBrush, QPalette, QPainter, QPixmap, QCursor
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QFrame, QWidget, QPushButton, qApp, QStyle, QComboBox, QLabel, QScrollBar, \
-    QStyleOptionSlider, QHBoxLayout, QVBoxLayout, QMenu, QAction
+    QStyleOptionSlider, QHBoxLayout, QVBoxLayout, QMenu, QAction, QDesktopWidget
 
 # Spell checker support
 from manuskript import settings
@@ -21,7 +21,7 @@ from manuskript.functions import Spellchecker
 
 
 class fullScreenEditor(QWidget):
-    def __init__(self, index, parent=None):
+    def __init__(self, index, parent=None, screenNumber=None):
         QWidget.__init__(self, parent)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
         self._background = None
@@ -161,6 +161,12 @@ class fullScreenEditor(QWidget):
         self.bottomPanel.setAutoHideVariable('autohide-bottom')
         self.topPanel.setAutoHideVariable('autohide-top')
         self.leftPanel.setAutoHideVariable('autohide-left')
+
+        # Set the screen to the same screen as the main window
+        if screenNumber is not None:
+            screenres = QDesktopWidget().screenGeometry(screenNumber);
+            self.move(QPoint(screenres.x(), screenres.y()));
+            self.resize(screenres.width(), screenres.height());
 
         # Connection
         self._index.model().dataChanged.connect(self.dataChanged)

--- a/manuskript/ui/editors/mainEditor.py
+++ b/manuskript/ui/editors/mainEditor.py
@@ -5,7 +5,7 @@ import locale
 from PyQt5.QtCore import QModelIndex, QRect, QPoint
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPixmap, QPainter, QIcon
-from PyQt5.QtWidgets import QWidget, qApp
+from PyQt5.QtWidgets import QWidget, qApp, QDesktopWidget
 
 from manuskript import settings
 from manuskript.enums import Outline
@@ -379,7 +379,10 @@ class mainEditor(QWidget, Ui_mainEditor):
 
     def showFullScreen(self):
         if self.currentEditor():
-            self._fullScreen = fullScreenEditor(self.currentEditor().currentIndex)
+            currentScreenNumber = QDesktopWidget().screenNumber(widget=self)
+            self._fullScreen = fullScreenEditor(
+                self.currentEditor().currentIndex,
+                screenNumber=currentScreenNumber)
 
     ###############################################################################
     # DICT AND STUFF LIKE THAT


### PR DESCRIPTION
For me and some others the distraction-free window would open on our secondary display #456 and  #687.
I suspect that it's because of my secondary display is on the left and the coordinate 0,0 is on that one.

This fix forces the window to be displayed on the same display as the main window by moving it to the coordinates of the screen of the main window and then calling `showFullScreen()`.