### PR TITLE
Fix #846 close Fullscreen when exiting main editor

### DIFF
--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -794,6 +794,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             # Remembering the current items (stores outlineItem's ID)
             settings.openIndexes = self.mainEditor.tabSplitter.openIndexes()
 
+            # Call close on the main window to clean children widgets
+            if self.mainEditor:
+                self.mainEditor.close()
+
             # Save data from models
             if settings.saveOnQuit:
                 self.saveDatas()

--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -184,7 +184,7 @@ class fullScreenEditor(QWidget):
         self.__exit__("Leaving fullScreenEditor via leaveFullScreen.")
 
     def __exit__(self, message):
-        print(message)
+        LOGGER.debug(message)
         self.showNormal()
         self.exited.emit()
         self.close()

--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -2,7 +2,7 @@
 # --!-- coding: utf8 --!--
 import os
 
-from PyQt5.QtCore import Qt, QSize, QPoint, QRect, QEvent, QTime, QTimer
+from PyQt5.QtCore import Qt, QSize, QPoint, QRect, QEvent, QTime, QTimer, pyqtSignal
 from PyQt5.QtGui import QFontMetrics, QColor, QBrush, QPalette, QPainter, QPixmap, QCursor
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QFrame, QWidget, QPushButton, qApp, QStyle, QComboBox, QLabel, QScrollBar, \
@@ -23,6 +23,8 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 class fullScreenEditor(QWidget):
+    exited = pyqtSignal()
+
     def __init__(self, index, parent=None, screenNumber=None):
         QWidget.__init__(self, parent)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
@@ -178,13 +180,13 @@ class fullScreenEditor(QWidget):
         # self.showMaximized()
         # self.show()
 
-    def __del__(self):
-        LOGGER.debug("Leaving fullScreenEditor via Destructor event.")
-        self.showNormal()
-        self.close()
-
     def leaveFullscreen(self):
+        self.__exit__("Leaving fullScreenEditor via leaveFullScreen.")
+
+    def __exit__(self, message):
+        print(message)
         self.showNormal()
+        self.exited.emit()
         self.close()
 
     def setLocked(self, val):
@@ -288,9 +290,7 @@ class fullScreenEditor(QWidget):
     def keyPressEvent(self, event):
         if event.key() in [Qt.Key_Escape, Qt.Key_F11] and \
                 not self._locked:
-            LOGGER.debug("Leaving fullScreenEditor via keyPressEvent.")
-            self.showNormal()
-            self.close()
+            self.__exit__("Leaving fullScreenEditor via keyPressEvent.")
         elif (event.modifiers() & Qt.AltModifier) and \
                 event.key() in [Qt.Key_PageUp, Qt.Key_PageDown, Qt.Key_Left, Qt.Key_Right]:
             if event.key() in [Qt.Key_PageUp, Qt.Key_Left]:

--- a/manuskript/ui/editors/mainEditor.py
+++ b/manuskript/ui/editors/mainEditor.py
@@ -154,6 +154,11 @@ class mainEditor(QWidget, Ui_mainEditor):
         for ts in reversed(self.allTabSplitters()):
             ts.closeSplit()
 
+    def close(self):
+        if self._fullScreen is not None:
+            LOGGER.error(self._fullScreen)
+            self._fullScreen.leaveFullscreen()
+
     def allTabs(self, tabWidget=None):
         """Returns all the tabs from the given tabWidget. If tabWidget is None, from the current tabWidget."""
         if tabWidget == None:
@@ -386,6 +391,11 @@ class mainEditor(QWidget, Ui_mainEditor):
             self._fullScreen = fullScreenEditor(
                 self.currentEditor().currentIndex,
                 screenNumber=currentScreenNumber)
+            # Clean the variable when closing fullscreen prevent errors
+            self._fullScreen.exited.connect(self.clearFullScreen)
+
+    def clearFullScreen(self):
+        self._fullScreen = None
 
     ###############################################################################
     # DICT AND STUFF LIKE THAT

--- a/manuskript/ui/editors/mainEditor.py
+++ b/manuskript/ui/editors/mainEditor.py
@@ -67,6 +67,7 @@ class mainEditor(QWidget, Ui_mainEditor):
         QWidget.__init__(self, parent)
         self.setupUi(self)
         self._updating = False
+        self._fullScreen = None
 
         self.mw = mainWindow()
 
@@ -156,7 +157,6 @@ class mainEditor(QWidget, Ui_mainEditor):
 
     def close(self):
         if self._fullScreen is not None:
-            LOGGER.error(self._fullScreen)
             self._fullScreen.leaveFullscreen()
 
     def allTabs(self, tabWidget=None):


### PR DESCRIPTION
If you have 2 screen you could have the main editor in between them and if you hit full-screen you could still have access to the exit buttons. When the the exit button was used with the full-screen window open, it would stay open.

This patch adds a cleaning method on the `MainEditor` to close the full-screen widget. It also adds a signal on the exiting full-screen so the `MainEditor` can clean the broken wrapper, so it'll not cause an error when trying `leaveFullScreen` with an empty C++ object.

It also removes the `__del__` function, I suspect it was there to try and solve this problem, but it was only causing an error when exiting the app because the object was already deleted.

Furthermore, it also moved duplicate code to a single function.