### PR TITLE
Fixing the tests for travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .idea
 .project
 .pydevproject
+.python-version
 .settings/org.eclipse.core.resources.prefs
 .vscode
 ExportTest

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # --!-- coding: utf8 --!--
-import imp
+import importlib
 import os
 import re
 
@@ -594,7 +594,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         if loadFromFile:
             # Load empty settings
-            imp.reload(settings)
+            importlib.reload(settings)
             settings.initDefaultValues()
 
             # Load data

--- a/manuskript/models/abstractItem.py
+++ b/manuskript/models/abstractItem.py
@@ -250,7 +250,8 @@ class abstractItem():
         # Setting data
         self._data[column] = data
 
-        if column == self.enum.ID:
+        # The _model will be none during splitting
+        if self._model and column == self.enum.ID:
             self._model.updateAvailableIDs(data)
 
         # Emit signal

--- a/manuskript/tests/models/test_outlineItem.py
+++ b/manuskript/tests/models/test_outlineItem.py
@@ -123,10 +123,10 @@ def test_modelStuff(outlineModelBasic):
     assert folder.findItemsContaining("VALUE", cols,  MW, True) == []
     assert folder.findItemsContaining("VALUE", cols,  MW, False) == [text2.ID()]
 
-    # Model, count and copy
+    # Model, count and copy    
     k = folder._model
-    folder.setModel(14)
-    assert text2._model == 14
+    folder.setModel(None)
+    assert text2._model is None
     folder.setModel(k)
     assert folder.columnCount() == len(folder.enum)
     text1 = text2.copy()

--- a/manuskript/ui/welcome.py
+++ b/manuskript/ui/welcome.py
@@ -2,7 +2,7 @@
 # --!-- coding: utf8 --!--
 
 import locale
-import imp
+import importlib
 import os
 
 from PyQt5.QtCore import QSettings, QRegExp, Qt, QDir
@@ -427,7 +427,7 @@ class welcome(QWidget, Ui_welcome):
         """Initialize a basic Manuskript project."""
 
         # Empty settings
-        imp.reload(settings)
+        importlib.reload(settings)
         settings.initDefaultValues()
         self.mw.loadEmptyDatas()
 


### PR DESCRIPTION
As mentioned in #857 there are tests in the project, but they've been failing for a while. This is the first step into fixing them. This is fixing the Linux part.

That PR fixes:
- 2 warnings with the deprecation of the `imp` module
- An error while splitting text caused by a self._model that is None
- An error with the test trying  to set a Model to an invalid value