### PR TITLE
Fix 860 languagetool get locale language

### DIFF
--- a/manuskript/functions/spellchecker.py
+++ b/manuskript/functions/spellchecker.py
@@ -530,7 +530,7 @@ def get_languagetool_languages():
     else:
         return languagetool.LanguageTool()._get_languages()
 
-def get_locale_language():
+def get_languagetool_locale_language():
     if use_language_check:
         return languagetool.get_locale_language()
     else:
@@ -583,7 +583,7 @@ class LanguageToolDictionary(BasicDictionary):
         if not LanguageToolDictionary.isInstalled():
             return None
 
-        default_locale = get_locale_language()
+        default_locale = get_languagetool_locale_language()
 
         if default_locale and not default_locale in get_languagetool_languages():
             default_locale = None

--- a/manuskript/functions/spellchecker.py
+++ b/manuskript/functions/spellchecker.py
@@ -530,6 +530,12 @@ def get_languagetool_languages():
     else:
         return languagetool.LanguageTool()._get_languages()
 
+def get_locale_language():
+    if use_language_check:
+        return languagetool.get_locale_language()
+    else:
+        return languagetool.utils.get_locale_language()
+
 class LanguageToolDictionary(BasicDictionary):
 
     def __init__(self, name):
@@ -577,7 +583,7 @@ class LanguageToolDictionary(BasicDictionary):
         if not LanguageToolDictionary.isInstalled():
             return None
 
-        default_locale = languagetool.get_locale_language()
+        default_locale = get_locale_language()
 
         if default_locale and not default_locale in get_languagetool_languages():
             default_locale = None


### PR DESCRIPTION
This is a fix for #860
Another difference between `language_check` and `language_tool_python` can cause a crash when starting Manuskript after installing `language_tool_python` in a fresh python setup.
The tools have a different emplacement for the function `get_locale_language`. I've applied the same kind of fix that was done for other differences.