### PR TITLE
Fix errors when language tool isn't installed

### DIFF
--- a/manuskript/functions/spellchecker.py
+++ b/manuskript/functions/spellchecker.py
@@ -538,10 +538,10 @@ def get_languagetool_locale_language():
 
 class LanguageToolDictionary(BasicDictionary):
 
-    if use_language_check:
-        _tool = None
-    else:
+    if languagetool:
         _tool = languagetool.LanguageTool()
+    else:
+        _tool = None
 
     def __init__(self, name):
         BasicDictionary.__init__(self, name)


### PR DESCRIPTION
This fix to remove the multiple language tools server has a small bug in it that is breaking the software when LanguageTool isn't present.

This fixes it by a validation on the `languagetool` variable instead of the `use_language_check` one.