### PR TITLE
Add configuration for github actions to test linux on pull requests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,46 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  test:
+    name: Test on node ${{ matrix.python_version }} and ${{ matrix.os }}
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6]
+        # python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-16.04]
+        # os: [ubuntu-16.04, ubuntu-latest, windows-latest, macos-10.15]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyqt5==5.9 lxml pytest pytest-faulthandler
+        sudo apt-get -qq update
+        sudo apt-get -qq install python3-pip python3-dev build-essential qt5-default libxml2-dev libxslt1-dev mesa-utils libgl1-mesa-glx libgl1-mesa-dev libxcb-xinerama0-dev
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Test with pytest
+      run: |
+        xvfb-run -s '-screen 0 640x480x24 +extension GLX' pytest -vs


### PR DESCRIPTION
Since the tests are now repaired again, let's add a GitHub action to test them on pull requests.

I took the decision to only test Linux for a few reasons, first it's the fastest, secondly free accounts only get 2,000 minutes of VM time per month. Mac OS VM time counts as timex10 and windows at x2.

Linux takes only 2 minutes, so we're good to up to 1000 commits per month (Which is fine for now, for the size of the project contributors) But if we add a Mac version with take 20minutes(x10) now we are limited to less than 10 commits...

