### PR TITLE
Fix missing root when using world building template

### DIFF
--- a/manuskript/models/worldModel.py
+++ b/manuskript/models/worldModel.py
@@ -317,7 +317,7 @@ class worldModel(QStandardItemModel, searchableModel):
                     i = self.addItem(d[0], parent)
                     addItems(d[1], i)
 
-        addItems(data, None)
+        addItems(data, self.invisibleRootItem())
         self.mw.treeWorld.expandAll()
 
     ###############################################################################


### PR DESCRIPTION
This is a fix for #866 adding the base root as the parent of the main categories so the tree is loaded properly.

See the result now:
![image](https://user-images.githubusercontent.com/1516034/115474029-93ebaa00-a20a-11eb-8825-2365ab6f4f23.png)
