### PR TITLE
Add item titles to warning dialog box when deleting files or folders

### DIFF
--- a/manuskript/ui/views/outlineBasics.py
+++ b/manuskript/ui/views/outlineBasics.py
@@ -312,13 +312,14 @@ class outlineBasics(QAbstractItemView):
         selection = self.getSelection()
 
         if not settings.dontShowDeleteWarning:
-            titles = "".join(["<li>{}</li>".format(s.internalPointer().title())
-                              for s in selection])
+            titlesList = "".join(["<li>{}</li>".format(s.internalPointer().title())
+                                  for s in selection])
             msg = QMessageBox(QMessageBox.Warning,
                 qApp.translate("outlineBasics", "About to remove"),
                 qApp.translate("outlineBasics",
-                    "<p><b>You're about to delete the following {} item(s):</b></p><ul>{}</ul><p>Are you sure?</p>"
-                    ).format(len(selection), titles),
+                    "<p><b>You're about to delete {} item(s).</b></p><p>Are you sure?</p>"
+                    ).format(len(selection)) +
+                    "<ul>{}</ul>".format(titlesList),
                 QMessageBox.Yes | QMessageBox.Cancel)
 
             chk = QCheckBox("&Don't show this warning in the future.")

--- a/manuskript/ui/views/outlineBasics.py
+++ b/manuskript/ui/views/outlineBasics.py
@@ -309,12 +309,16 @@ class outlineBasics(QAbstractItemView):
         """
         Shows a warning, and then deletes currently selected indexes.
         """
+        selection = self.getSelection()
+
         if not settings.dontShowDeleteWarning:
+            titles = "".join(["<li>{}</li>".format(s.internalPointer().title())
+                              for s in selection])
             msg = QMessageBox(QMessageBox.Warning,
                 qApp.translate("outlineBasics", "About to remove"),
                 qApp.translate("outlineBasics",
-                    "<p><b>You're about to delete {} item(s).</b></p><p>Are you sure?</p>"
-                    ).format(len(self.getSelection())),
+                    "<p><b>You're about to delete the following {} item(s):</b></p><ul>{}</ul><p>Are you sure?</p>"
+                    ).format(len(selection), titles),
                 QMessageBox.Yes | QMessageBox.Cancel)
 
             chk = QCheckBox("&Don't show this warning in the future.")
@@ -327,7 +331,7 @@ class outlineBasics(QAbstractItemView):
             if chk.isChecked():
                 settings.dontShowDeleteWarning = True
 
-        self.model().removeIndexes(self.getSelection())
+        self.model().removeIndexes(selection)
 
     def duplicate(self):
         """


### PR DESCRIPTION
See issue #931.

I initially thought of using the wording: 

"You are about to delete the following 2 item(s):
* myfile1
* myfile2
Are you sure?"

but this would break all the existing translations. So instead I went for the following wording:

<img width="386" alt="Screenshot 2021-09-04 at 19 23 02" src="https://user-images.githubusercontent.com/10974856/132103234-aa8c11de-24be-4e91-b0fa-8669c656c801.png">

Has been tested on MacOS only.
