### PR TITLE
hard_line_breaks support

### DIFF
--- a/manuskript/exporter/pandoc/abstractPlainText.py
+++ b/manuskript/exporter/pandoc/abstractPlainText.py
@@ -177,6 +177,9 @@ class pandocSettings(markdownSettings):
         "disable-YAML": pandocSetting("EXT-yaml_metadata_block", "checkbox", "",
                                       qApp.translate("Export", "Disable YAML metadata block.\nUse that if you get YAML related error."),
                                       minVersion="1.12"),
+        "hard-line-breaks": pandocSetting("EXT-hard_line_block", "checkbox", "",
+                                      qApp.translate("Export", "Enable the support on markdown for line break on new line."),
+                                      minVersion="1.16"),
 
         # Specific
         "ref-link":     pandocSetting("--reference-links", "checkbox", "markdown rst",
@@ -367,6 +370,8 @@ class pandocSettings(markdownSettings):
                     extensions += "-yaml_metadata_block"
                 if name == "epub3" and s.widget.isChecked():
                     toFormat = "epub3"
+                if name == "hard-line-breaks" and s.widget.isChecked():
+                    extensions += "+hard_line_breaks"
 
         r = ["--from=markdown" + extensions,
              "--to={}".format(toFormat)]


### PR DESCRIPTION
So I found the commit implementing in pandoc to set the pandoc minimum version https://github.com/jgm/pandoc/commit/8a101cffe36f4d6301ff45fd1b491bad1fcf1244

This should fix a part of a request there.

~~I was not able to test it.~~ I tested it and works :-)