### PR TITLE
Potential fix for #719, #1001: data loss when reordering items in upward direction

### DIFF
--- a/manuskript/models/abstractItem.py
+++ b/manuskript/models/abstractItem.py
@@ -224,14 +224,22 @@ class abstractItem():
         if max([self.IDs.count(i) for i in self.IDs if i]) != 1:
             LOGGER.warning("There are some items with overlapping IDs: %s", [i for i in self.IDs if i and self.IDs.count(i) != 1])
 
+        _IDs = [self.ID()]
         def checkChildren(item):
+            "Check recursively every children and give them unique, non-empty, non-zero IDs."
             for c in item.children():
                 _id = c.ID()
-                if not _id or _id == "0":
+                if not _id or _id == "0" or _id in _IDs:
                     c.getUniqueID()
+                    LOGGER.warning("* Item {} '{}' is given new unique ID: '{}'".format(_id, c.title(), c.ID()))
+                _IDs.append(_id)
                 checkChildren(c)
 
         checkChildren(self)
+
+        # Not sure if self.IDs is still useful (it was used in the old unique ID generating system at least).
+        # It might be deleted everywhere. But just in the meantime, it should at least be up to date.
+        self.IDs = self.listAllIDs()
 
     def listAllIDs(self):
         IDs = [self.ID()]

--- a/manuskript/models/abstractModel.py
+++ b/manuskript/models/abstractModel.py
@@ -438,7 +438,18 @@ class abstractModel(QAbstractItemModel):
 
             for item in items:
                 if item.ID() in IDs:
-                    item.getUniqueID(recursive=True)
+                    # Items don't get new IDs, because they are not part of a model yet,
+                    # so the following call does nothing:
+                    # item.getUniqueID(recursive=True)
+
+                    # Instead we need to remove IDs (recursively) in all copied items, so that they
+                    # will receive new ones when inserted within the model.
+                    def removeIDs(i):
+                        i.setData(item.enum.ID, None)
+                        for c in i.children():
+                            removeIDs(c)
+
+                    removeIDs(item)
 
         r = self.insertItems(items, beginRow, parent)
 


### PR DESCRIPTION
I got some issue with this (#719, #1001) as well.

With that fix, I haven't been able to reproduce the bug.

# Description of the fix

In my testing, it happens only when items have duplicate IDs (though I haven't been able to understand why):

> WARNING> There are some items with overlapping IDs: ['5', '5']

And this happens *at least* if items are copied and pasted (or dragged and dropped with `CTRL`).

The issue comes from here:

https://github.com/olivierkes/manuskript/blob/0182a43b8ec5bf16217da659078843d201388b2b/manuskript/models/abstractModel.py#L429-L441

Since `getUniqueID` does not do anything if item has no model:

https://github.com/olivierkes/manuskript/blob/0182a43b8ec5bf16217da659078843d201388b2b/manuskript/models/abstractItem.py#L207-L215

and at that moment in the drop, items have no models.

Well, the easier fix here is to simply remove items IDs, so they get new ones when theyre created, which this commit does.

# Further things to consider

*IF* this effectiverly fixes this bug, in my mind the `WARNING> There are some items with overlapping IDs:` should be treated with more seriousness. It shouldn't be allowed that IDs are not unique.

