### PR TITLE
Add settable color palettes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .settings/org.eclipse.core.resources.prefs
 .vscode
 .vimrc
+desktop.ini
 ExportTest
 Notes.t2t
 dist

--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -13,6 +13,7 @@ from PyQt5.QtWidgets import QApplication, qApp, QStyleFactory
 
 from manuskript.functions import appPath, writablePath
 from manuskript.version import getVersion
+from manuskript.ui import themes
 
 try:
     faulthandler.enable()
@@ -55,6 +56,14 @@ def prepare(arguments, tests=False):
     if settings.contains("applicationStyle"):
         style = settings.value("applicationStyle")
         app.setStyle(style)
+
+    # Set palette from QSettings
+    app.setPalette(themes.light)  # Start off with light theme
+    if settings.contains("applicationPalette"):
+        palette = settings.value("applicationPalette")
+        if hasattr(themes, palette):
+            # If settings has valid theme name, use requested
+            app.setPalette(getattr(themes, palette))
 
     # Translation process
     appTranslator = QTranslator(app)

--- a/manuskript/ui/themes/__init__.py
+++ b/manuskript/ui/themes/__init__.py
@@ -1,0 +1,2 @@
+from .dark import palette as dark
+from .light import palette as light

--- a/manuskript/ui/themes/dark.py
+++ b/manuskript/ui/themes/dark.py
@@ -1,0 +1,23 @@
+from PyQt5.QtGui import QColor, QPalette
+
+__all__ = ("colors", "palette")
+
+colors = {
+    QPalette.Window: QColor(53, 53, 53),
+    QPalette.WindowText: QColor("white"),
+    QPalette.Base: QColor(25, 25, 25),
+    QPalette.AlternateBase: QColor(53, 53, 53),
+    QPalette.ToolTipBase: QColor("white"),
+    QPalette.ToolTipText: QColor("white"),
+    QPalette.Text: QColor("white"),
+    QPalette.Button: QColor(53, 53, 53),
+    QPalette.ButtonText: QColor("white"),
+    QPalette.BrightText: QColor("red"),
+    QPalette.Link: QColor(42, 130, 218),
+    QPalette.Highlight: QColor(42, 130, 218),
+    QPalette.HighlightedText: QColor("black"),
+}
+
+palette = QPalette()
+for key, val in colors.items():
+    palette.setColor(key, val)

--- a/manuskript/ui/themes/light.py
+++ b/manuskript/ui/themes/light.py
@@ -1,0 +1,23 @@
+from PyQt5.QtGui import QColor, QPalette
+
+__all__ = ("colors", "palette")
+
+colors = {
+    QPalette.Window: QColor("#f2f2f2"),
+    QPalette.WindowText: QColor("black"),
+    QPalette.Base: QColor("white"),
+    QPalette.AlternateBase: QColor(202, 202, 202),
+    QPalette.ToolTipBase: QColor("black"),
+    QPalette.ToolTipText: QColor("black"),
+    QPalette.Text: QColor("black"),
+    QPalette.Button: QColor(202, 202, 202),
+    QPalette.ButtonText: QColor("black"),
+    QPalette.BrightText: QColor("red"),
+    QPalette.Link: QColor(42, 130, 218),
+    QPalette.Highlight: QColor(42, 130, 218),
+    QPalette.HighlightedText: QColor("white"),
+}
+
+palette = QPalette()
+for key, val in colors.items():
+    palette.setColor(key, val)


### PR DESCRIPTION
Allows users to specify what colour palette they want the app to show in. For now, I've added a dark and light palette but I tried to make it as easy as possible for other contributors to add colour schemes.

I couldn't get my head around the Settings UI and wasn't sure how best to implement it even if I could, so I've set it to default to light and left the settings option for more experienced contributors to figure out. So long as there's a setting called `applicationPalette`, its value should be used in much the same way as `style` to set the palette, and I've tested it by manually switching between `themes.light` and `themes.dark` and the palette works!

Light palette:
![image](https://user-images.githubusercontent.com/25686106/209439997-6ad9f813-a757-43db-90c7-3a4ed3800373.png)

Dark palette:
![image](https://user-images.githubusercontent.com/25686106/209440009-93c72e97-7f85-461e-9842-e92e5c6ebaeb.png)
