### PR TITLE
Fix to error  #1095

### DIFF
--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -469,7 +469,7 @@ def search(searchRegex, text):
     :return:                list of tuples (startPos, endPos)
     """
     if text is not None:
-        return [(m.start(), m.end(), getSearchResultContext(text, m.start(), m.end())) for m in searchRegex.finditer(text)]
+        return [(m.start(), m.end(), getSearchResultContext(text, m.start(), m.end())) for m in searchRegex.finditer(str(text))]
     else:
         return []
 


### PR DESCRIPTION
Error #1095 is an error where searching crashes when typing  anything it gives an error:

  File "/home/jim/manuskript/bin/../manuskript/functions/__init__.py", line 472, in search
    return [(m.start(), m.end(), getSearchResultContext(text, m.start(), m.end())) for m in searchRegex.finditer(text)]
TypeError: expected string or bytes-like object

It happened to me also. I was able to fix it by just putting a str() around the text in the last bit so its:
    return [(m.start(), m.end(), getSearchResultContext(text, m.start(), m.end())) for m in searchRegex.finditer(str(text))]

This is my first pull request ever so sorry if I did anything wrong. Tell me and I'll fix any problems.
