### PR TITLE
Fix grammatical error in Brazilian Portuguese

### DIFF
--- a/i18n/manuskript_pt_BR.ts
+++ b/i18n/manuskript_pt_BR.ts
@@ -574,7 +574,7 @@
     <message>
         <location filename="../manuskript/ui/mainWindow.py" line="1538"/>
         <source>&amp;Frequency Analyzer</source>
-        <translation>Analizador de &amp;Frequencia</translation>
+        <translation>Analisador de &amp;Frequência</translation>
     </message>
     <message>
         <location filename="../manuskript/ui/mainWindow.py" line="1422"/>

--- a/i18n/manuskript_pt_BR.ts
+++ b/i18n/manuskript_pt_BR.ts
@@ -59,12 +59,12 @@
     <message>
         <location filename="../manuskript/ui/tools/frequency_ui.py" line="103"/>
         <source>Frequency Analyzer</source>
-        <translation>Analisador de Freqüência</translation>
+        <translation>Analisador de Frequência</translation>
     </message>
     <message>
         <location filename="../manuskript/ui/tools/frequency_ui.py" line="108"/>
         <source>Word frequency</source>
-        <translation>Freqüência de palavras</translation>
+        <translation>Frequência de palavras</translation>
     </message>
     <message>
         <location filename="../manuskript/ui/tools/frequency_ui.py" line="104"/>

--- a/i18n/manuskript_pt_BR.ts
+++ b/i18n/manuskript_pt_BR.ts
@@ -439,7 +439,7 @@
     <message>
         <location filename="../manuskript/ui/mainWindow.py" line="1508"/>
         <source>&amp;View</source>
-        <translation>&amp;Vizualizar</translation>
+        <translation>&amp;Visualizar</translation>
     </message>
     <message>
         <location filename="../manuskript/ui/mainWindow.py" line="1509"/>

--- a/i18n/manuskript_pt_BR.ts
+++ b/i18n/manuskript_pt_BR.ts
@@ -1324,7 +1324,7 @@ Então expanda isso para um parágrafo, depois para uma página e, em seguida, p
     <message>
         <location filename="../manuskript/ui/settings_ui.py" line="1924"/>
         <source>Automatically save every</source>
-        <translation>Salvar automaticamente todos</translation>
+        <translation>Salvar automaticamente a cada</translation>
     </message>
     <message>
         <location filename="../manuskript/ui/settings_ui.py" line="1925"/>


### PR DESCRIPTION
Changed "vizualizar" to "visualizar" to correct a grammatical error in the text. "Vizualizar" is not a correct spelling in Brazilian Portuguese, so it was replaced with "visualizar". This change improves the accuracy and readability of the text in Portuguese.