### PR TITLE
Fix manuskriptw startup error

### DIFF
--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -16,7 +16,7 @@ from manuskript.version import getVersion
 
 try:
     faulthandler.enable()
-except AttributeError:
+except (AttributeError, RuntimeError):
     print("Faulthandler failed")
 
 import logging


### PR DESCRIPTION
Added catch of RuntimeError to `faulthandler.enable()` except which is triggered on when sys.stderr is none, what happens right now in the manuskriptw build.

Fixes #1138 