### PR TITLE
Fix inconsistent newline handling across operating systems

### DIFF
--- a/manuskript/exporter/manuskript/plainText.py
+++ b/manuskript/exporter/manuskript/plainText.py
@@ -96,7 +96,7 @@ class plainText(basicFormat):
                 LOGGER.error("No content. Nothing saved.")
                 return
 
-            with open(filename, "w", encoding='utf8') as f:
+            with open(filename, "w", encoding="utf8", newline="\n") as f:
                 f.write(content)
 
     def preview(self, settingsWidget, previewWidget):
@@ -217,4 +217,3 @@ class plainText(basicFormat):
         content += "\n"
 
         return content
-

--- a/manuskript/functions/spellchecker.py
+++ b/manuskript/functions/spellchecker.py
@@ -23,7 +23,7 @@ try:
 
     if distutils.version.LooseVersion(symspellpy.__version__) < SYMSPELLPY_MIN_VERSION:
         symspellpy = None
-    
+
 except ImportError:
     symspellpy = None
 
@@ -148,7 +148,7 @@ class BasicDictionary:
         self._customDict = set()
         customPath = self.getCustomDictionaryPath()
         try:
-            with gzip.open(customPath, "rt", encoding='utf-8') as f:
+            with gzip.open(customPath, "rt", encoding='utf-8', newline="\n") as f:
                 self._customDict = set(json.loads(f.read()))
                 for word in self._customDict:
                     self._dict.create_dictionary_entry(word, self.CUSTOM_COUNT)
@@ -250,7 +250,7 @@ class BasicDictionary:
 
     def _saveCustomDict(self):
         customPath = self.getCustomDictionaryPath()
-        with gzip.open(customPath, "wt") as f:
+        with gzip.open(customPath, "wt", newline="\n") as f:
             f.write(json.dumps(list(self._customDict)))
 
 
@@ -393,7 +393,7 @@ class SymSpellDictionary(BasicDictionary):
             if pyspellchecker:
                 path = os.path.join(pyspellchecker.__path__[0], "resources", "{}.json.gz".format(self.name))
                 if os.path.exists(path):
-                    with gzip.open(path, "rt", encoding='utf-8') as f:
+                    with gzip.open(path, "rt", encoding='utf-8', newline="\n") as f:
                         data = json.loads(f.read())
                         for key in data:
                             self._dict.create_dictionary_entry(key, data[key])

--- a/manuskript/importer/folderImporter.py
+++ b/manuskript/importer/folderImporter.py
@@ -46,7 +46,7 @@ class folderImporter(abstractImporter):
                 fName, fExt = os.path.splitext(f)
                 if fExt.lower() in ext:
                     try:
-                        with open(os.path.join(dirpath, f), "r", encoding="utf-8") as fr:
+                        with open(os.path.join(dirpath, f), "r", encoding="utf-8", newline="\n") as fr:
                             content = fr.read()
                         child = outlineItem(title=fName, _type="md", parent=item)
                         child._data[Outline.text] = content
@@ -122,7 +122,3 @@ class folderImporter(abstractImporter):
         self.addSettingsTo(group)
 
         return widget
-
-
-
-

--- a/manuskript/importer/markdownImporter.py
+++ b/manuskript/importer/markdownImporter.py
@@ -65,7 +65,7 @@ class markdownImporter(abstractImporter):
 
         if not fromString:
             # Read file
-            with open(filePath, "r", encoding="utf-8") as f:
+            with open(filePath, "r", encoding="utf-8", newline="\n") as f:
                 txt = f.read()
         else:
             txt = fromString

--- a/manuskript/loadSave.py
+++ b/manuskript/loadSave.py
@@ -56,7 +56,7 @@ def loadProject(project):
 
     # Not a zip
     else:
-        with open(project, "r", encoding="utf-8") as f:
+        with open(project, "r", encoding="utf-8", newline="\n") as f:
             version = int(f.read())
 
     LOGGER.info("Loading: %s", project)

--- a/manuskript/load_save/version_1.py
+++ b/manuskript/load_save/version_1.py
@@ -388,7 +388,7 @@ def saveProject(zip=None):
                         filesWithPermissionErrors.append(filename)
                 else:
                     try:
-                        with open(filename, "w", encoding='utf8') as f:
+                        with open(filename, "w", encoding="utf8", newline="\n") as f:
                             f.write(content)
                     except PermissionError as e:
                         LOGGER.error("Cannot open file " + filename + " for writing: " + e.strerror)
@@ -423,7 +423,7 @@ def saveProject(zip=None):
 
         # Write the project file's content
         try:
-            with open(project, "w", encoding='utf8') as f:
+            with open(project, "w", encoding="utf8", newline="\n") as f:
                 f.write("1")  # Format number
         except PermissionError as e:
             LOGGER.error("Cannot open file " + project + " for writing: " + e.strerror)
@@ -689,7 +689,7 @@ def loadProject(project, zip=None):
                 else:
                     try:
                         filename = os.path.join(dirpath, f)
-                        with open(filename, "r", encoding="utf8") as fo:
+                        with open(filename, "r", encoding="utf8", newline="\n") as fo:
                             files[os.path.join(p, f)] = fo.read()
                     except PermissionError as e:
                         LOGGER.error("Cannot open file " + filename + ": " + e.strerror)
@@ -1127,5 +1127,3 @@ def parseMMDFile(text, asDict=False):
         return md, body
     else:
         return mdd, body
-
-

--- a/manuskript/ui/exporters/manuskript/plainTextSettings.py
+++ b/manuskript/ui/exporters/manuskript/plainTextSettings.py
@@ -128,7 +128,7 @@ class exporterSettings(QWidget, Ui_exporterSettings):
     def loadSettings(self):
         filename = self.getSettingsPath()
         if os.path.exists(filename):
-            with open(filename, "r", encoding="utf-8") as f:
+            with open(filename, "r", encoding="utf-8", newline="\n") as f:
                 self.settings = json.load(f)
             self.updateFromSettings()
 
@@ -138,7 +138,7 @@ class exporterSettings(QWidget, Ui_exporterSettings):
 
     def writeSettings(self):
         self.getSettings()
-        with open(self.getSettingsPath(), 'w', encoding="utf-8") as f:
+        with open(self.getSettingsPath(), 'w', encoding="utf-8", newline="\n") as f:
             # json.dumps(json.loads(json.dumps(allSettings)), indent=4, sort_keys=True)
             json.dump(self.settings, f, indent=4, sort_keys=True)
 
@@ -419,6 +419,3 @@ class exporterSettings(QWidget, Ui_exporterSettings):
 
         lst.setMinimumSize(QSize(0, h+2))
         lst.setMaximumSize(QSize(16777215, h+2))
-
-
-


### PR DESCRIPTION
Adjusted open calls to use `\n` as newline for all platforms instead of guessing it. I'm not sure here whether all made changes are really necessary, but we shouldn't let python guess the newline character used for reading / writing files in non-binary mode.

Change might lead to not being able to open existing projects on windows which then need to be converted somehow.

Fixes #1169 