### PR TITLE
Skip comments in word count

### DIFF
--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -34,10 +34,9 @@ def wordCount(text):
     count = 0
     in_comment = False
     for word in words:
-        if in_comment:
-            if word == '-->':
-                in_comment = False
-        else:
+        if in_comment and word == '-->':
+            in_comment = False
+        if not in_comment:
             if word == '<!--':
                 in_comment = True
             else:

--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -30,18 +30,7 @@ def safeTranslate(qApp, group, text):
         return text
 
 def wordCount(text):
-    words = re.findall(r"\S+", text)
-    count = 0
-    in_comment = False
-    for word in words:
-        if in_comment and word == '-->':
-            in_comment = False
-        if not in_comment:
-            if word == '<!--':
-                in_comment = True
-            else:
-                count += 1
-    return count
+    return len(re.findall(r"\S+", re.sub(r"(<!--).+?(-->)", "", text)))
 
 
 def charCount(text, use_spaces = True):

--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -30,7 +30,19 @@ def safeTranslate(qApp, group, text):
         return text
 
 def wordCount(text):
-    return len(re.findall(r"\S+", text))
+    words = re.findall(r"\S+", text)
+    count = 0
+    in_comment = False
+    for word in words:
+        if in_comment:
+            if word == '-->':
+                in_comment = False
+        else:
+            if word == '<!--':
+                in_comment = True
+            else:
+                count += 1
+    return count
 
 
 def charCount(text, use_spaces = True):


### PR DESCRIPTION
Hi! I'm not sure if others have run into this, but there have been a few times were I've left notes laying around and thought I was closer to my word count goal than I actually was. Wanted to see if others might appreciate dropping comments from the word count.

Notable caveat: I'm not sure a good way to handle the possibility of comment tokens inside of a code block without re-implementing a lot more parsing logic. I also understand that the current solution is much much more elegant than this proposal.

So, I'd happily take suggestions and fully support shooting this down, but I figured it was worth a shot. Maybe someone sharper than me would have a better idea for it :sweat_smile:

Thanks for taking a look!