### PR TITLE
Fix regex for ignoring multi-line comments.

### DIFF
--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -30,7 +30,7 @@ def safeTranslate(qApp, group, text):
         return text
 
 def wordCount(text):
-    return len(re.findall(r"\S+", re.sub(r"(<!--)[\s\S]+?(-->)", "", text)))
+    return len(re.findall(r"\S+", re.sub(r"(<!--).+?(-->)", "", text, flags=re.DOTALL)))
 
 
 def charCount(text, use_spaces = True):

--- a/manuskript/functions/__init__.py
+++ b/manuskript/functions/__init__.py
@@ -30,7 +30,7 @@ def safeTranslate(qApp, group, text):
         return text
 
 def wordCount(text):
-    return len(re.findall(r"\S+", re.sub(r"(<!--).+?(-->)", "", text)))
+    return len(re.findall(r"\S+", re.sub(r"(<!--)[\s\S]+?(-->)", "", text)))
 
 
 def charCount(text, use_spaces = True):


### PR DESCRIPTION
`.*` doesn't pick up newlines, so multi-line comments were not being correctly dropped from the word count.
`[\s\S]` is a simple workaround, though any of `[\w\W]`, `[\d\D]`, or `(.|\s)` should also work.