### PR TITLE
Update spellchecker.py And Fixed crashing

### DIFF
--- a/manuskript/ui/views/corkDelegate.py
+++ b/manuskript/ui/views/corkDelegate.py
@@ -384,7 +384,7 @@ class corkDelegate(QStyledItemDelegate):
 
                 # Draw Summary
                 # One line
-        if lineSummary:
+        if lineSummary and textColor:
             p.save()
             f = QFont(option.font)
             f.setBold(True)
@@ -396,7 +396,7 @@ class corkDelegate(QStyledItemDelegate):
             p.restore()
 
             # Full summary
-        if fullSummary:
+        if fullSummary and textColor:
             p.save()
             p.setFont(option.font)
             p.setPen(textColor)

--- a/manuskript/ui/views/corkDelegate.py
+++ b/manuskript/ui/views/corkDelegate.py
@@ -384,6 +384,11 @@ class corkDelegate(QStyledItemDelegate):
 
                 # Draw Summary
                 # One line
+        #checking that textColor is actually defined before we use it
+        try:
+            textColor
+        except:
+            textColor = None
         if lineSummary and textColor:
             p.save()
             f = QFont(option.font)


### PR DESCRIPTION
Corrected issue where words within certain quotations would show up as incorrectly spelled (ex: 'I'm fine') would indicate both words are misspelled
![image](https://github.com/olivierkes/manuskript/assets/16183762/f3e20a74-2894-4240-bb41-5d7904324914)
In the image, "I'm fine" is confirmed to be in the dictionary as in a previous line it is not showing up as misspelled, however in single quotes it doesn't work. I made sure that it would work with any additional punctuation and not just apostrophes or single quotes just in case.  