### PR TITLE
Crash on spellcheck context menu #1224

### DIFF
--- a/manuskript/functions/spellchecker.py
+++ b/manuskript/functions/spellchecker.py
@@ -363,7 +363,7 @@ class PySpellcheckerDictionary(BasicDictionary):
 
     def getSuggestions(self, word):
         candidates = self._dict.candidates(word)
-        if word in candidates:
+        if candidates and word in candidates:
             candidates.remove(word)
         return candidates
 

--- a/manuskript/ui/views/textEditView.py
+++ b/manuskript/ui/views/textEditView.py
@@ -620,10 +620,11 @@ class textEditView(QTextEdit):
 
                         selectedWord = cursor.selectedText()
 
-                    for word in match.replacements:
-                        action = self.SpellAction(word, spell_menu)
-                        action.correct.connect(self.correctWord)
-                        spell_menu.addAction(action)
+                    if match.replacements:
+                        for word in match.replacements:
+                            action = self.SpellAction(word, spell_menu)
+                            action.correct.connect(self.correctWord)
+                            spell_menu.addAction(action)
 
                     # Adds: add to dictionary
                     addAction = QAction(self.tr("&Add to dictionary"), popup_menu)
@@ -635,7 +636,7 @@ class textEditView(QTextEdit):
 
                     # Only add the spelling suggests to the menu if there are
                     # suggestions.
-                    if len(match.replacements) > 0:
+                    if match.replacements and len(match.replacements) > 0:
                         # Adds: suggestions
                         popup_menu.insertMenu(popup_menu.actions()[0], spell_menu)
                 else:


### PR DESCRIPTION
Pull request for issue 1224:
Right clicking on unknown words (for spellchecker pyspellchecker and symspellpy) lead to crash. 
In these cases the object was None and therefore not iterable. The fix in code should solve this issue.