### PR TITLE
Prevent crash when spellcheck candidates is None

### DIFF
--- a/manuskript/functions/spellchecker.py
+++ b/manuskript/functions/spellchecker.py
@@ -363,7 +363,7 @@ class PySpellcheckerDictionary(BasicDictionary):
 
     def getSuggestions(self, word):
         candidates = self._dict.candidates(word)
-        if word in candidates:
+        if candidates is not None and word in candidates:
             candidates.remove(word)
         return candidates
 


### PR DESCRIPTION
This addresses a crash when right clicking a misspelled word that has no suggestions. Documented in this issue: https://github.com/olivierkes/manuskript/issues/1224