### PR TITLE
Fix ipython import

### DIFF
--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -205,7 +205,10 @@ def launch(arguments, app, MW = None):
     # https://github.com/ipython/ipykernel/blob/master/examples/embedding/internal_ipkernel.py
     if arguments.console:
         try:
-            from IPython.lib.kernel import connect_qtconsole
+            try:
+                from IPython.lib.kernel import connect_qtconsole
+            except ImportError:
+                from ipykernel import connect_qtconsole
             from ipykernel.kernelapp import IPKernelApp
             # Only to ensure matplotlib QT mainloop integration is available
             import matplotlib

--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -201,8 +201,8 @@ def launch(arguments, app, MW = None):
     # Support for IPython Jupyter QT Console as a debugging aid.
     # Last argument must be --console to enable it
     # Code reference :
-    # https://github.com/ipython/ipykernel/blob/master/examples/embedding/ipkernel_qtapp.py
-    # https://github.com/ipython/ipykernel/blob/master/examples/embedding/internal_ipkernel.py
+    # https://github.com/ipython/ipykernel/blob/main/examples/embedding/ipkernel_qtapp.py
+    # https://github.com/ipython/ipykernel/blob/main/examples/embedding/internal_ipkernel.py
     if arguments.console:
         try:
             try:


### PR DESCRIPTION
I ran into an issue while trying to debug another issue :)

```
Console mode requested but error initializing IPython : No module named 'IPython.lib.kernel'
To make use of the Interactive IPython QT Console, make sure you install :
$ pip3 install ipython qtconsole matplotlib
```

I found this documented elsewhere, [it seems to have moved location](https://github.com/ipython/ipython/issues/13610#issuecomment-1081994316)

I made no attempts to test this anywhere but my own machine so far, but the change seems pretty benign

I also updated a few links that I noticed along the way (which still worked, but redirected you first)