### PR TITLE
Fix crash when clicking outline

### DIFF
--- a/manuskript/main.py
+++ b/manuskript/main.py
@@ -220,7 +220,7 @@ def launch(arguments, app, MW = None):
             kernel.initialize(['python', '--matplotlib=qt'])
 
             # Create the console in a new process and connect
-            console = connect_qtconsole(kernel.abs_connection_file, profile=kernel.profile)
+            console = connect_qtconsole(kernel.abs_connection_file)
 
             # Export MW and app variable to the console's namespace
             kernel.shell.user_ns['MW'] = MW

--- a/manuskript/ui/collapsibleGroupBox.py
+++ b/manuskript/ui/collapsibleGroupBox.py
@@ -51,12 +51,12 @@ class collapsibleGroupBox(QGroupBox):
         groupBox = opt
 
         # // Draw frame
-        textRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxLabel)
-        checkBoxRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxCheckBox)
+        textRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxLabel, None)
+        checkBoxRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxCheckBox, None)
 
         p.save()
-        titleRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxFrame)
-        # r.setBottom(style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxContents).top())
+        titleRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxFrame, None)
+        # r.setBottom(style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxContents).top(), None)
         titleRect.setHeight(textRect.height())
         titleRect.moveTop(textRect.top())
 
@@ -72,7 +72,7 @@ class collapsibleGroupBox(QGroupBox):
             frame.features = groupBox.features
             frame.lineWidth = groupBox.lineWidth
             frame.midLineWidth = groupBox.midLineWidth
-            frame.rect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxFrame)
+            frame.rect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxFrame, None)
             p.save()
             region = QRegion(groupBox.rect)
             if groupBox.text:

--- a/manuskript/ui/collapsibleGroupBox.py
+++ b/manuskript/ui/collapsibleGroupBox.py
@@ -51,12 +51,12 @@ class collapsibleGroupBox(QGroupBox):
         groupBox = opt
 
         # // Draw frame
-        textRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxLabel, None)
-        checkBoxRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxCheckBox, None)
+        textRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxLabel)
+        checkBoxRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxCheckBox)
 
         p.save()
-        titleRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxFrame, None)
-        # r.setBottom(style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxContents).top(), None)
+        titleRect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxFrame)
+        # r.setBottom(style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxContents).top())
         titleRect.setHeight(textRect.height())
         titleRect.moveTop(textRect.top())
 
@@ -72,7 +72,7 @@ class collapsibleGroupBox(QGroupBox):
             frame.features = groupBox.features
             frame.lineWidth = groupBox.lineWidth
             frame.midLineWidth = groupBox.midLineWidth
-            frame.rect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxFrame, None)
+            frame.rect = style.subControlRect(style.CC_GroupBox, opt, style.SC_GroupBoxFrame)
             p.save()
             region = QRegion(groupBox.rect)
             if groupBox.text:

--- a/manuskript/ui/editors/fullScreenEditor.py
+++ b/manuskript/ui/editors/fullScreenEditor.py
@@ -525,7 +525,7 @@ class myScrollBar(QScrollBar):
         # painter.restore()
 
         # slider
-        r = style.subControlRect(style.CC_ScrollBar, opt, style.SC_ScrollBarSlider)
+        r = style.subControlRect(style.CC_ScrollBar, opt, style.SC_ScrollBarSlider, None)
         painter.fillRect(r, self._color)
         painter.end()
 

--- a/manuskript/ui/views/outlineDelegates.py
+++ b/manuskript/ui/views/outlineDelegates.py
@@ -183,7 +183,7 @@ class outlineCharacterDelegate(QStyledItemDelegate):
         if itemIndex.isValid() and self.mdlCharacter.data(itemIndex) not in ["", None]:
             opt = QStyleOptionComboBox()
             opt.rect = option.rect
-            r = qApp.style().subControlRect(QStyle.CC_ComboBox, opt, QStyle.SC_ComboBoxArrow)
+            r = qApp.style().subControlRect(QStyle.CC_ComboBox, opt, QStyle.SC_ComboBoxArrow, None)
             option.rect = r
             qApp.style().drawPrimitive(QStyle.PE_IndicatorArrowDown, option, painter)
 
@@ -295,7 +295,7 @@ class outlineStatusDelegate(QStyledItemDelegate):
         if index.isValid() and index.internalPointer().data(Outline.status) not in ["", None, "0", 0]:
             opt = QStyleOptionComboBox()
             opt.rect = option.rect
-            r = qApp.style().subControlRect(QStyle.CC_ComboBox, opt, QStyle.SC_ComboBoxArrow)
+            r = qApp.style().subControlRect(QStyle.CC_ComboBox, opt, QStyle.SC_ComboBoxArrow, None)
             option.rect = r
             qApp.style().drawPrimitive(QStyle.PE_IndicatorArrowDown, option, painter)
 
@@ -361,6 +361,6 @@ class outlineLabelDelegate(QStyledItemDelegate):
         if index.isValid() and index.internalPointer().data(Outline.label) not in ["", None, "0", 0]:
             opt = QStyleOptionComboBox()
             opt.rect = option.rect
-            r = qApp.style().subControlRect(QStyle.CC_ComboBox, opt, QStyle.SC_ComboBoxArrow)
+            r = qApp.style().subControlRect(QStyle.CC_ComboBox, opt, QStyle.SC_ComboBoxArrow, None)
             option.rect = r
             qApp.style().drawPrimitive(QStyle.PE_IndicatorArrowDown, option, painter)

--- a/manuskript/ui/views/outlineDelegates.py
+++ b/manuskript/ui/views/outlineDelegates.py
@@ -29,8 +29,8 @@ class outlineTitleDelegate(QStyledItemDelegate):
         opt = QStyleOptionViewItem(option)
         self.initStyleOption(opt, index)
 
-        iconRect = style.subElementRect(style.SE_ItemViewItemDecoration, opt)
-        textRect = style.subElementRect(style.SE_ItemViewItemText, opt)
+        iconRect = style.subElementRect(style.SE_ItemViewItemDecoration, opt, None)
+        textRect = style.subElementRect(style.SE_ItemViewItemText, opt, None)
 
         # Background
         style.drawPrimitive(style.PE_PanelItemViewItem, opt, painter)


### PR DESCRIPTION
Fixes the crash in #1299, which ended up being very simple.

I wrote a decent bit of explanation in both of the commits, but for the short summary: At least in the more recent versions of PyQt5, `subElementRect` for `qproxystyle` (which is used in `paint`) expects three arguments, instead of having a default value for widget of `None`.

This shouldn't be a problem even if older versions do have a default value, since it would already be `None`.