### PR TITLE
fix: when loading ignores files that are not text files.

### DIFF
--- a/manuskript/load_save/version_1.py
+++ b/manuskript/load_save/version_1.py
@@ -694,6 +694,10 @@ def loadProject(project, zip=None):
                         filename = os.path.join(dirpath, f)
                         with open(filename, 'rt', encoding="utf8") as fo:
                             files[os.path.join(p, f)] = fo.read()
+
+                    except (UnicodeDecodeError, FileNotFoundError, IsADirectoryError) as e:
+                         LOGGER.error("Ignore file: "+ filename + "because of the error " + e.reason)
+                         
                     except PermissionError as e:
                         LOGGER.error("Cannot open file " + filename + ": " + e.strerror)
                         errors.append(fo)


### PR DESCRIPTION
This contribution fixes issue [https://github.com/olivierkes/manuskript/issues/1323](https://github.com/olivierkes/manuskript/issues/1323).

In this small change, an exception is handled if the file cannot be opened because it is not a text file; it simply ignores it and loads the project.

This is my first contribution to the project, and I wanted to do something simple, although I have ideas for refactoring the project loading to make it more robust. If you are open to some refactoring, I would appreciate any feedback so I can get started, knowing what is currently being sought in the project.


