### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+lxml==5.4.0
+pyenchant==3.2.2
+PyQt5==5.15.11
+PyQt5-Qt5==5.15.17
+PyQt5_sip==12.17.0


### PR DESCRIPTION
Adding requirements.txt for an easier installation of dependencies for developers with the following commands:

create a python venv:  `python -m venv venv`

activate venv:
    MacOS or Linux: `source venv/bin/activate`
    Windows: `venv\Scripts\activate`

Install dependencies:
    `pip install -r requirements.txt`


At any point in the future whenever a new dependency is added to the project we can add it using:
`pip3 freeze > requirements.txt`

With this we only need to run the commands and we should be able to run the project properly.
