### PR TITLE
refactor(architecture): extract ProjectManager class from mainWindow

### DIFF
--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -22,6 +22,7 @@ from manuskript.models.characterModel import characterModel
 from manuskript.models import outlineModel
 from manuskript.models.plotModel import plotModel
 from manuskript.models.worldModel import worldModel
+from manuskript.projectManager import ProjectManager
 from manuskript.settingsWindow import settingsWindow
 from manuskript.ui import style
 from manuskript.ui import characterInfoDialog
@@ -76,6 +77,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.sessionStartWordCount = 0  # Used to track session targets
         self.history = History()
         self._previousSelectionEmpty = True
+        self.projectManager = ProjectManager(self)
 
         self.readSettings()
 
@@ -113,11 +115,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         # Main Menu:: File
         self.actOpen.triggered.connect(self.welcome.openFile)
-        self.actSave.triggered.connect(self.saveDatas)
+        self.actSave.triggered.connect(self.projectManager.saveDatas)
         self.actSaveAs.triggered.connect(self.welcome.saveAsFile)
         self.actImport.triggered.connect(self.doImport)
         self.actCompile.triggered.connect(self.doCompile)
-        self.actCloseProject.triggered.connect(self.closeProject)
+        self.actCloseProject.triggered.connect(self.projectManager.closeProject)
         self.actQuit.triggered.connect(self.close)
 
         # Main menu:: Edit
@@ -905,191 +907,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.actBack.setEnabled(event.position > 0)
         self.actForward.setEnabled(event.position < event.count - 1)
 
-    ###############################################################################
-    # LOAD AND SAVE
-    ###############################################################################
-
-    def loadProject(self, project, loadFromFile=True):
-        """Loads the project ``project``.
-
-        If ``loadFromFile`` is False, then it does not load datas from file.
-        It assumes that the datas have been populated in a different way."""
-
-        # Convert project path to OS norm
-        project = os.path.normpath(project)
-
-        if loadFromFile and not os.path.exists(project):
-            LOGGER.warning("The file {} does not exist. Has it been moved or deleted?".format(project))
-            F.statusMessage(
-                    self.tr("The file {} does not exist. Has it been moved or deleted?").format(project), importance=3)
-            return
-
-        if loadFromFile:
-            # Load empty settings
-            importlib.reload(settings)
-            settings.initDefaultValues()
-
-            # Load data
-            self.loadEmptyDatas()
-            
-            if not self.loadDatas(project):
-                self.closeProject()
-                return
-
-        self.makeConnections()
-
-        # Load settings
-        if settings.openIndexes and settings.openIndexes != [""]:
-            self.mainEditor.tabSplitter.restoreOpenIndexes(settings.openIndexes)
-        self.generateViewMenu()
-        self.mainEditor.sldCorkSizeFactor.setValue(settings.corkSizeFactor)
-        self.actSpellcheck.setChecked(settings.spellcheck)
-        self.toggleSpellcheck(settings.spellcheck)
-        self.updateMenuDict()
-        self.setDictionary()
-
-        iconSize = settings.viewSettings["Tree"]["iconSize"]
-        self.treeRedacOutline.setIconSize(QSize(iconSize, iconSize))
-        self.mainEditor.setFolderView(settings.folderView)
-        self.mainEditor.updateFolderViewButtons(settings.folderView)
-        self.mainEditor.tabSplitter.updateStyleSheet()
-        self.tabMain.setCurrentIndex(settings.lastTab)
-        self.mainEditor.updateCorkBackground()
-        if settings.viewMode == "simple":
-            self.setViewModeSimple()
-        else:
-            self.setViewModeFiction()
-
-        # Set autosave
-        self.saveTimer = QTimer()
-        self.saveTimer.setInterval(settings.autoSaveDelay * 60 * 1000)
-        self.saveTimer.setSingleShot(False)
-        self.saveTimer.timeout.connect(self.saveDatas)
-        if settings.autoSave:
-            self.saveTimer.start()
-
-        # Set autosave if no changes
-        self.saveTimerNoChanges = QTimer()
-        self.saveTimerNoChanges.setInterval(settings.autoSaveNoChangesDelay * 1000)
-        self.saveTimerNoChanges.setSingleShot(True)
-        self.mdlFlatData.dataChanged.connect(self.startTimerNoChanges)
-        self.mdlOutline.dataChanged.connect(self.startTimerNoChanges)
-        self.mdlCharacter.dataChanged.connect(self.startTimerNoChanges)
-        self.mdlPlots.dataChanged.connect(self.startTimerNoChanges)
-        self.mdlWorld.dataChanged.connect(self.startTimerNoChanges)
-        self.mdlStatus.dataChanged.connect(self.startTimerNoChanges)
-        self.mdlLabels.dataChanged.connect(self.startTimerNoChanges)
-
-        self.saveTimerNoChanges.timeout.connect(self.saveDatas)
-        self.saveTimerNoChanges.stop()
-
-        # UI
-        for i in [self.actOpen, self.menuRecents]:
-            i.setEnabled(False)
-        for i in [self.actSave, self.actSaveAs, self.actCloseProject,
-                  self.menuEdit, self.menuView, self.menuOrganize,
-                  self.menuNavigate,
-                  self.menuTools, self.menuHelp, self.actImport,
-                  self.actCompile, self.actSettings]:
-            i.setEnabled(True)
-        # We force to emit even if it opens on the current tab
-        self.tabMain.currentChanged.emit(settings.lastTab)
-
-        # Make sure we can update the window title later.
-        self.currentProject = project
-        self.projectDirty = False
-        QSettings().setValue("lastProject", project)
-
-        item = self.mdlOutline.rootItem
-        wc = item.data(Outline.wordCount)
-        self.sessionStartWordCount = int(wc) if wc != "" else 0
-        # Add project name to Window's name
-        self.setWindowTitle(self.projectName() + " - " + self.tr("Manuskript"))
-
-        # Reset history
-        self.history.reset()
-
-        # Show main Window
-        self.switchToProject()
-
-    def handleUnsavedChanges(self):
-        """
-        There may be some currently unsaved changes, but the action the user triggered
-        will result in the project or application being closed. To save, or not to save?
-
-        Or just bail out entirely?
-
-        Sometimes it is best to just ask.
-        """
-
-        if not self.projectDirty:
-            return True  # no unsaved changes, all is good
-
-        msg = QMessageBox(QMessageBox.Question,
-            self.tr("Save project?"),
-            "<p><b>" +
-                self.tr("Save changes to project \"{}\" before closing?").format(self.projectName()) +
-            "</b></p>" +
-            "<p>" +
-                self.tr("Your changes will be lost if you don't save them.") +
-            "</p>",
-            QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel)
-
-        ret = msg.exec()
-
-        if ret == QMessageBox.Cancel:
-            return False  # the situation has not been handled, cancel action
-
-        if ret == QMessageBox.Save:
-            self.saveDatas()
-
-        return True  # the situation has been handled
-
-
-    def closeProject(self):
-
-        if not self.currentProject:
-            return
-
-        # Make sure data is saved.
-        if (self.projectDirty and settings.saveOnQuit == True):
-             self.saveDatas()
-        elif not self.handleUnsavedChanges():
-             return  # user cancelled action
-
-        # Close open tabs in editor
-        self.mainEditor.closeAllTabs()
-
-        self.currentProject = None
-        self.projectDirty = None
-        QSettings().setValue("lastProject", "")
-
-        # Clear datas
-        self.loadEmptyDatas()
-        self.saveTimer.stop()
-        self.saveTimerNoChanges.stop()
-        loadSave.clearSaveCache()
-
-        self.breakConnections()
-
-        # UI
-        for i in [self.actOpen, self.menuRecents]:
-            i.setEnabled(True)
-        for i in [self.actSave, self.actSaveAs, self.actCloseProject,
-                  self.menuEdit, self.menuView, self.menuOrganize,
-                  self.menuTools, self.menuHelp, self.actImport,
-                  self.actCompile, self.actSettings]:
-            i.setEnabled(False)
-
-        # Set Window's name - no project loaded
-        self.setWindowTitle(self.tr("Manuskript"))
-
-        # Reload recent files
-        self.welcome.updateValues()
-
-        # Show welcome dialog
-        self.switchToWelcome()
-
     def readSettings(self):
         # Load State and geometry
         sttgns = QSettings(qApp.organizationName(), qApp.applicationName())
@@ -1127,133 +944,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self._toolbarState = sttgns.value("toolbar")
         else:
             self._toolbarState = ""
-
-    def closeEvent(self, event):
-        # Specific settings to save before quitting
-        settings.lastTab = self.tabMain.currentIndex()
-
-        if self.currentProject:
-            # Remembering the current items (stores outlineItem's ID)
-            settings.openIndexes = self.mainEditor.tabSplitter.openIndexes()
-
-            # Call close on the main window to clean children widgets
-            if self.mainEditor:
-                self.mainEditor.close()
-
-            # Save data from models
-            if settings.saveOnQuit:
-                self.saveDatas()
-            elif not self.handleUnsavedChanges():
-                event.ignore() # user opted to cancel the close action
-
-            # closeEvent
-            # QMainWindow.closeEvent(self, event)  # Causing segfaults?
-
-        # Close non-modal windows if they are open.
-        if self.td:
-            self.td.close()
-        if self.fw:
-            self.fw.close()
-
-        # User may have canceled close event, so make sure we indeed want to close.
-        # This is necessary because self.updateDockVisibility() hides UI elements.
-        if event.isAccepted():
-            # Save State and geometry and other things
-            appSettings = QSettings(qApp.organizationName(), qApp.applicationName())
-            appSettings.setValue("geometry", self.saveGeometry())
-            appSettings.setValue("windowState", self.saveState())
-            appSettings.setValue("metadataState", self.redacMetadata.saveState())
-            appSettings.setValue("revisionsState", self.redacMetadata.revisions.saveState())
-            appSettings.setValue("splitterRedacH", self.splitterRedacH.saveState())
-            appSettings.setValue("splitterRedacV", self.splitterRedacV.saveState())
-            appSettings.setValue("toolbar", self.toolbar.saveState())
-
-            # If we are not in the welcome window, we update the visibility
-            # of the docks widgets
-            if self.stack.currentIndex() == 1:
-                self.updateDockVisibility()
-
-            # Storing the visibility of docks to restore it on restart
-            appSettings.setValue("docks", self._dckVisibility)
-
-    def startTimerNoChanges(self):
-        """
-        Something changed in the project that requires auto-saving.
-        """
-        self.projectDirty = True
-
-        if settings.autoSaveNoChanges:
-            self.saveTimerNoChanges.start()
-
-    def saveDatas(self, projectName=None):
-        """Saves the current project (in self.currentProject).
-
-        If ``projectName`` is given, currentProject becomes projectName.
-        In other words, it "saves as...".
-        """
-
-        if projectName:
-            self.currentProject = projectName
-            QSettings().setValue("lastProject", projectName)
-
-        # Stop the timer before saving: if auto-saving fails (bugs out?) we don't want it
-        # to keep trying and continuously hitting the failure condition. Nor do we want to
-        # risk a scenario where the timer somehow triggers a new save while saving.
-        self.saveTimerNoChanges.stop()
-
-        if self.currentProject is None:
-            # No UI feedback here as this code path indicates a race condition that happens
-            # after the user has already closed the project through some way. But in that
-            # scenario, this code should not be reachable to begin with.
-            LOGGER.error("There is no current project to save.")
-            return
-
-        r = loadSave.saveProject()  # version=0
-
-        projectName = os.path.basename(self.currentProject)
-        if r:
-            self.projectDirty = False  # successful save, clear dirty flag
-
-            feedback = self.tr("Project {} saved.").format(projectName)
-            F.statusMessage(feedback, importance=0)
-            LOGGER.info("Project {} saved.".format(projectName))
-        else:
-            feedback = self.tr("WARNING: Project {} not saved.").format(projectName)
-            F.statusMessage(feedback, importance=3)
-            LOGGER.warning("Project {} not saved.".format(projectName))
-
-    def loadEmptyDatas(self):
-        self.mdlFlatData = QStandardItemModel(self)
-        self.mdlCharacter = characterModel(self)
-        self.mdlLabels = QStandardItemModel(self)
-        self.mdlStatus = QStandardItemModel(self)
-        self.mdlPlots = plotModel(self)
-        self.mdlOutline = outlineModel(self)
-        self.mdlWorld = worldModel(self)
-
-    def loadDatas(self, project):
-        errors = loadSave.loadProject(project)
-
-        # Giving some feedback
-        if not errors:
-            LOGGER.info("Project {} loaded.".format(project))
-            F.statusMessage(
-                    self.tr("Project {} loaded.").format(project), 2000)
-        else:
-            LOGGER.error("Project {} loaded with some errors:".format(project))
-            for e in errors:
-                LOGGER.error(" * {} wasn't found in project file.".format(e))
-            F.statusMessage(
-                    self.tr("Project {} loaded with some errors.").format(project), 5000, importance = 3)
-        
-        if project in errors:
-            LOGGER.error("Loading project {} failed.".format(project))
-            F.statusMessage(
-                    self.tr("Loading project {} failed.").format(project), 5000, importance = 3)
-
-            return False
-        
-        return True
 
     ###############################################################################
     # MAIN CONNECTIONS

--- a/manuskript/projectManager.py
+++ b/manuskript/projectManager.py
@@ -1,0 +1,283 @@
+import importlib
+import os
+
+from PyQt5.QtCore import QSettings, QTimer, QSize
+from PyQt5.QtGui import QStandardItemModel
+from PyQt5.QtWidgets import QMessageBox
+
+from manuskript import settings, loadSave
+import manuskript.functions as F
+from manuskript.logging import getLogFilePath
+from manuskript.models.characterModel import characterModel
+from manuskript.models import outlineModel
+from manuskript.models.plotModel import plotModel
+from manuskript.models.worldModel import worldModel
+from manuskript.enums import Outline
+
+import logging
+LOGGER = logging.getLogger(__name__)
+
+
+class ProjectManager:
+    def __init__(self, window):
+        self.window = window
+        self.saveTimer = QTimer()
+        self.saveTimerNoChanges = QTimer()
+
+    def loadProject(self, project, loadFromFile=True):
+        """Loads the project ``project``.
+
+        If ``loadFromFile`` is False, then it does not load datas from file.
+        It assumes that the datas have been populated in a different way."""
+
+        # Convert project path to OS norm
+        project = os.path.normpath(project)
+
+        if loadFromFile and not os.path.exists(project):
+            LOGGER.warning("The file {} does not exist. Has it been moved or deleted?".format(project))
+            F.statusMessage(
+                    self.window.tr("The file {} does not exist. Has it been moved or deleted?").format(project), importance=3)
+            return
+
+        if loadFromFile:
+            # Load empty settings
+            importlib.reload(settings)
+            settings.initDefaultValues()
+
+            # Load data
+            self.loadEmptyDatas()
+            
+            if not self.loadDatas(project):
+                self.closeProject()
+                return
+
+        self.window.makeConnections()
+
+        # Load settings
+        if settings.openIndexes and settings.openIndexes != [""]:
+            self.window.mainEditor.tabSplitter.restoreOpenIndexes(settings.openIndexes)
+        self.window.generateViewMenu()
+        self.window.mainEditor.sldCorkSizeFactor.setValue(settings.corkSizeFactor)
+        self.window.actSpellcheck.setChecked(settings.spellcheck)
+        self.window.toggleSpellcheck(settings.spellcheck)
+        self.window.updateMenuDict()
+        self.window.setDictionary()
+
+        iconSize = settings.viewSettings["Tree"]["iconSize"]
+        self.window.treeRedacOutline.setIconSize(QSize(iconSize, iconSize))
+        self.window.mainEditor.setFolderView(settings.folderView)
+        self.window.mainEditor.updateFolderViewButtons(settings.folderView)
+        self.window.mainEditor.tabSplitter.updateStyleSheet()
+        self.window.tabMain.setCurrentIndex(settings.lastTab)
+        self.window.mainEditor.updateCorkBackground()
+        if settings.viewMode == "simple":
+            self.window.setViewModeSimple()
+        else:
+            self.window.setViewModeFiction()
+
+        # Set autosave
+        self.saveTimer.setInterval(settings.autoSaveDelay * 60 * 1000)
+        self.saveTimer.setSingleShot(False)
+        self.saveTimer.timeout.connect(self.saveDatas)
+        if settings.autoSave:
+            self.saveTimer.start()
+
+        # Set autosave if no changes
+        self.saveTimerNoChanges.setInterval(settings.autoSaveNoChangesDelay * 1000)
+        self.saveTimerNoChanges.setSingleShot(True)
+        self.window.mdlFlatData.dataChanged.connect(self.startTimerNoChanges)
+        self.window.mdlOutline.dataChanged.connect(self.startTimerNoChanges)
+        self.window.mdlCharacter.dataChanged.connect(self.startTimerNoChanges)
+        self.window.mdlPlots.dataChanged.connect(self.startTimerNoChanges)
+        self.window.mdlWorld.dataChanged.connect(self.startTimerNoChanges)
+        self.window.mdlStatus.dataChanged.connect(self.startTimerNoChanges)
+        self.window.mdlLabels.dataChanged.connect(self.startTimerNoChanges)
+
+        self.saveTimerNoChanges.timeout.connect(self.saveDatas)
+        self.saveTimerNoChanges.stop()
+
+        # UI
+        for i in [self.window.actOpen, self.window.menuRecents]:
+            i.setEnabled(False)
+        for i in [self.window.actSave, self.window.actSaveAs, self.window.actCloseProject,
+                  self.window.menuEdit, self.window.menuView, self.window.menuOrganize,
+                  self.window.menuNavigate,
+                  self.window.menuTools, self.window.menuHelp, self.window.actImport,
+                  self.window.actCompile, self.window.actSettings]:
+            i.setEnabled(True)
+        # We force to emit even if it opens on the current tab
+        self.window.tabMain.currentChanged.emit(settings.lastTab)
+
+        # Make sure we can update the window title later.
+        self.window.currentProject = project
+        self.window.projectDirty = False
+        QSettings().setValue("lastProject", project)
+
+        item = self.window.mdlOutline.rootItem
+        wc = item.data(Outline.wordCount)
+        self.window.sessionStartWordCount = int(wc) if wc != "" else 0
+        # Add project name to Window's name
+        self.window.setWindowTitle(self.window.projectName() + " - " + self.window.tr("Manuskript"))
+
+        # Reset history
+        self.window.history.reset()
+
+        # Show main Window
+        self.window.switchToProject()
+
+    def handleUnsavedChanges(self):
+        """
+        There may be some currently unsaved changes, but the action the user triggered
+        will result in the project or application being closed. To save, or not to save?
+
+        Or just bail out entirely?
+
+        Sometimes it is best to just ask.
+        """
+
+        if not self.window.projectDirty:
+            return True  # no unsaved changes, all is good
+
+        msg = QMessageBox(QMessageBox.Question,
+            self.window.tr("Save project?"),
+            "<p><b>" +
+                self.window.tr("Save changes to project \"{}\" before closing?").format(self.window.projectName()) +
+            "</b></p>" +
+            "<p>" +
+                self.window.tr("Your changes will be lost if you don't save them.") +
+            "</p>",
+            QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel)
+
+        ret = msg.exec()
+
+        if ret == QMessageBox.Cancel:
+            return False  # the situation has not been handled, cancel action
+
+        if ret == QMessageBox.Save:
+            self.saveDatas()
+
+        return True  # the situation has been handled
+
+
+    def closeProject(self):
+
+        if not self.window.currentProject:
+            return
+
+        # Make sure data is saved.
+        if (self.window.projectDirty and settings.saveOnQuit == True):
+             self.saveDatas()
+        elif not self.handleUnsavedChanges():
+             return  # user cancelled action
+
+        # Close open tabs in editor
+        self.window.mainEditor.closeAllTabs()
+
+        self.window.currentProject = None
+        self.window.projectDirty = None
+        QSettings().setValue("lastProject", "")
+
+        # Clear datas
+        self.loadEmptyDatas()
+        self.saveTimer.stop()
+        self.saveTimerNoChanges.stop()
+        loadSave.clearSaveCache()
+
+        self.window.breakConnections()
+
+        # UI
+        for i in [self.window.actOpen, self.window.menuRecents]:
+            i.setEnabled(True)
+        for i in [self.window.actSave, self.window.actSaveAs, self.window.actCloseProject,
+                  self.window.menuEdit, self.window.menuView, self.window.menuOrganize,
+                  self.window.menuTools, self.window.menuHelp, self.window.actImport,
+                  self.window.actCompile, self.window.actSettings]:
+            i.setEnabled(False)
+
+        # Set Window's name - no project loaded
+        self.window.setWindowTitle(self.window.tr("Manuskript"))
+
+        # Reload recent files
+        self.window.welcome.updateValues()
+
+        # Show welcome dialog
+        self.window.switchToWelcome()
+
+    def startTimerNoChanges(self):
+        """
+        Something changed in the project that requires auto-saving.
+        """
+        self.window.projectDirty = True
+
+        if settings.autoSaveNoChanges:
+            self.saveTimerNoChanges.start()
+
+    def saveDatas(self, projectName=None):
+        """Saves the current project (in self.currentProject).
+
+        If ``projectName`` is given, currentProject becomes projectName.
+        In other words, it "saves as...".
+        """
+
+        if projectName:
+            self.window.currentProject = projectName
+            QSettings().setValue("lastProject", projectName)
+
+        # Stop the timer before saving: if auto-saving fails (bugs out?) we don't want it
+        # to keep trying and continuously hitting the failure condition. Nor do we want to
+        # risk a scenario where the timer somehow triggers a new save while saving.
+        self.saveTimerNoChanges.stop()
+
+        if self.window.currentProject is None:
+            # No UI feedback here as this code path indicates a race condition that happens
+            # after the user has already closed the project through some way. But in that
+            # scenario, this code should not be reachable to begin with.
+            LOGGER.error("There is no current project to save.")
+            return
+
+        r = loadSave.saveProject()  # version=0
+
+        projectName = os.path.basename(self.window.currentProject)
+        if r:
+            self.window.projectDirty = False  # successful save, clear dirty flag
+
+            feedback = self.window.tr("Project {} saved.").format(projectName)
+            F.statusMessage(feedback, importance=0)
+            LOGGER.info("Project {} saved.".format(projectName))
+        else:
+            feedback = self.window.tr("WARNING: Project {} not saved.").format(projectName)
+            F.statusMessage(feedback, importance=3)
+            LOGGER.warning("Project {} not saved.".format(projectName))
+
+    def loadEmptyDatas(self):
+        self.window.mdlFlatData = QStandardItemModel(self.window)
+        self.window.mdlCharacter = characterModel(self.window)
+        self.window.mdlLabels = QStandardItemModel(self.window)
+        self.window.mdlStatus = QStandardItemModel(self.window)
+        self.window.mdlPlots = plotModel(self.window)
+        self.window.mdlOutline = outlineModel(self.window)
+        self.window.mdlWorld = worldModel(self.window)
+
+    def loadDatas(self, project):
+        errors = loadSave.loadProject(project)
+
+        # Giving some feedback
+        if not errors:
+            LOGGER.info("Project {} loaded.".format(project))
+            F.statusMessage(
+                    self.window.tr("Project {} loaded.").format(project), 2000)
+        else:
+            LOGGER.error("Project {} loaded with some errors:".format(project))
+            for e in errors:
+                LOGGER.error(" * {} wasn't found in project file.".format(e))
+            F.statusMessage(
+                    self.window.tr("Project {} loaded with some errors.").format(project), 5000, importance = 3)
+        
+        if project in errors:
+            LOGGER.error("Loading project {} failed.".format(project))
+            F.statusMessage(
+                    self.window.tr("Loading project {} failed.").format(project), 5000, importance = 3)
+
+            return False
+        
+        return True

--- a/manuskript/settingsWindow.py
+++ b/manuskript/settingsWindow.py
@@ -386,8 +386,8 @@ class settingsWindow(QWidget, Ui_Settings):
         settings.saveToZip = True if self.chkSaveToZip.checkState() else False
         settings.autoSaveDelay = int(self.txtAutoSave.text())
         settings.autoSaveNoChangesDelay = int(self.txtAutoSaveNoChanges.text())
-        self.mw.saveTimer.setInterval(settings.autoSaveDelay * 60 * 1000)
-        self.mw.saveTimerNoChanges.setInterval(settings.autoSaveNoChangesDelay * 1000)
+        self.mw.projectManager.saveTimer.setInterval(settings.autoSaveDelay * 60 * 1000)
+        self.mw.projectManager.saveTimerNoChanges.setInterval(settings.autoSaveNoChangesDelay * 1000)
 
     ####################################################################################################
     #                                           REVISION                                               #

--- a/manuskript/tests/conftest.py
+++ b/manuskript/tests/conftest.py
@@ -22,7 +22,7 @@ def MWNoProject(MW):
     """
     Take the MainWindow and close andy possibly open project.
     """
-    MW.closeProject()
+    MW.projectManager.closeProject()
     assert MW.currentProject == None
     return MW
 
@@ -34,7 +34,7 @@ def MWEmptyProject(MW):
     import tempfile
     tf = tempfile.NamedTemporaryFile(suffix=".msk")
 
-    MW.closeProject()
+    MW.projectManager.closeProject()
     assert MW.currentProject == None
     MW.welcome.createFile(tf.name, overwrite=True)
     assert MW.currentProject != None
@@ -66,7 +66,7 @@ def MWSampleProject(MW):
     import shutil
     shutil.copyfile(src, tf.name)
     shutil.copytree(src[:-4], tf.name[:-4])
-    MW.loadProject(tf.name)
+    MW.projectManager.loadProject(tf.name)
     assert MW.currentProject != None
 
     return MW

--- a/manuskript/tests/test_projectManager.py
+++ b/manuskript/tests/test_projectManager.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from manuskript.projectManager import ProjectManager
+
+class TestProjectManager(unittest.TestCase):
+
+    def setUp(self):
+        self.window = MagicMock()
+        self.project_manager = ProjectManager(self.window)
+
+    @patch('manuskript.functions.statusMessage')
+    @patch('os.path.exists')
+    def test_load_project_file_not_exists(self, mock_exists, mock_status_message):
+        # Test case: file doesn't exist
+        mock_exists.return_value = False
+        expected_message = "The file {} does not exist. Has it been moved or deleted?"
+        self.window.tr.return_value = expected_message
+        
+        self.project_manager.loadProject("non_existent_project.msk")
+        
+        # Verify the translation function was called with correct message
+        self.window.tr.assert_called_with("The file {} does not exist. Has it been moved or deleted?")
+        # Verify statusMessage was called with the translated message and importance=3
+        mock_status_message.assert_called_once_with(expected_message.format("non_existent_project.msk"), importance=3)
+        
+    @patch('manuskript.functions.statusMessage')
+    @patch('os.path.exists')
+    def test_load_project_file_exists(self, mock_exists, mock_status_message):
+        # Test case: file exists - should proceed with loading
+        mock_exists.return_value = True
+        
+        # Mock the loading methods to avoid complex setup
+        with patch.object(self.project_manager, 'loadEmptyDatas'), \
+             patch.object(self.project_manager, 'loadDatas', return_value=True), \
+             patch.object(self.window, 'makeConnections'), \
+             patch('manuskript.settings.openIndexes', []), \
+             patch('manuskript.settings.viewSettings', {"Tree": {"iconSize": 24}}):
+            
+            self.project_manager.loadProject("existing_project.msk")
+            
+            # Should not call the error message about file not existing
+            error_calls = [call for call in self.window.tr.call_args_list 
+                          if "does not exist" in str(call)]
+            self.assertEqual(len(error_calls), 0, "Should not show file not found error")
+            
+            # Should not call statusMessage with importance=3 (error level)
+            error_status_calls = [call for call in mock_status_message.call_args_list 
+                                if len(call.kwargs) > 0 and call.kwargs.get('importance') == 3]
+            self.assertEqual(len(error_status_calls), 0, "Should not show error status message")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/manuskript/tests/test_projectManager_timer.py
+++ b/manuskript/tests/test_projectManager_timer.py
@@ -1,0 +1,123 @@
+import unittest
+from unittest.mock import MagicMock, patch, ANY
+from PyQt5.QtCore import QTimer, QObject
+from manuskript.projectManager import ProjectManager
+
+class TestProjectManagerTimer(unittest.TestCase):
+
+    def setUp(self):
+        self.window = MagicMock()
+        self.window.tr = lambda x: x
+
+        # Create separate mocks for each timer instance
+        self.mock_save_timer = MagicMock()
+        self.mock_save_timer.timeout = MagicMock()
+        self.mock_save_timer_no_changes = MagicMock()
+        self.mock_save_timer_no_changes.timeout = MagicMock()
+        
+        # Mock QTimer to return different instances for each call
+        self.timer_instances = [self.mock_save_timer, self.mock_save_timer_no_changes]
+        self.timer_call_count = 0
+        
+        def mock_qtimer_constructor():
+            timer = self.timer_instances[self.timer_call_count]
+            self.timer_call_count += 1
+            return timer
+            
+        self.mock_qtimer_class = patch("manuskript.projectManager.QTimer", side_effect=mock_qtimer_constructor).start()
+
+        # Patch QStandardItemModel to avoid TypeError
+        self.mock_qstandarditemmodel_class = patch("manuskript.projectManager.QStandardItemModel", autospec=True).start()
+
+        self.project_manager = ProjectManager(self.window)
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _load_project_helper(self, auto_save, auto_save_no_changes):
+        with patch("manuskript.projectManager.settings") as mock_settings, \
+             patch("importlib.reload"), \
+             patch("os.path.exists", return_value=True), \
+             patch.object(self.project_manager, "loadDatas", return_value=True), \
+             patch.object(self.project_manager, "loadEmptyDatas"), \
+             patch.object(self.window, "makeConnections"):
+            mock_settings.autoSave = auto_save
+            mock_settings.autoSaveDelay = 15
+            mock_settings.autoSaveNoChanges = auto_save_no_changes
+            mock_settings.autoSaveNoChangesDelay = 3
+            mock_settings.openIndexes = []
+            mock_settings.viewSettings = {"Tree": {"iconSize": 24}}
+            mock_settings.lastTab = 0
+            mock_settings.corkSizeFactor = 100
+            mock_settings.spellcheck = False
+            mock_settings.folderView = False
+            mock_settings.viewMode = "fiction"
+
+            self.project_manager.loadProject("dummy_project.msk")
+
+    def test_save_timer_starts_on_load_with_autosave_enabled(self):
+        self._load_project_helper(auto_save=True, auto_save_no_changes=False)
+        # Timer interval is always set during loadProject
+        self.mock_save_timer.setInterval.assert_called_with(15 * 60 * 1000)
+        # Timer only starts if autoSave is enabled
+        self.mock_save_timer.start.assert_called_once()
+
+    def test_save_timer_does_not_start_with_autosave_disabled(self):
+        self._load_project_helper(auto_save=False, auto_save_no_changes=False)
+        self.mock_save_timer.start.assert_not_called()
+
+    def test_save_timer_stops_on_project_close(self):
+        self._load_project_helper(auto_save=True, auto_save_no_changes=False)
+        with patch.object(self.project_manager, "handleUnsavedChanges", return_value=True), \
+             patch.object(self.project_manager, "loadEmptyDatas"):
+            self.project_manager.closeProject()
+        self.mock_save_timer.stop.assert_called_once()
+
+    def test_save_timer_no_changes_starts_on_data_change(self):
+        self._load_project_helper(auto_save=True, auto_save_no_changes=True)
+        # Reset the mock to ignore calls made during project loading
+        self.mock_save_timer_no_changes.start.reset_mock()
+        self.project_manager.startTimerNoChanges()
+        self.mock_save_timer_no_changes.start.assert_called_once()
+        self.assertTrue(self.window.projectDirty)
+
+    def test_save_timer_no_changes_does_not_start_with_autosave_disabled(self):
+        self._load_project_helper(auto_save=False, auto_save_no_changes=False)
+        # Need to mock settings during the actual startTimerNoChanges call
+        with patch("manuskript.projectManager.settings") as mock_settings:
+            mock_settings.autoSaveNoChanges = False
+            self.project_manager.startTimerNoChanges()
+        self.mock_save_timer_no_changes.start.assert_not_called()
+
+    def test_save_timer_no_changes_stops_on_project_close(self):
+        self._load_project_helper(auto_save=True, auto_save_no_changes=True)
+        self.project_manager.startTimerNoChanges()
+        with patch.object(self.project_manager, "handleUnsavedChanges", return_value=True), \
+             patch.object(self.project_manager, "loadEmptyDatas"):
+            self.project_manager.closeProject()
+        self.mock_save_timer_no_changes.stop.assert_called()
+
+    def test_save_timer_no_changes_stops_after_saving(self):
+        self._load_project_helper(auto_save=True, auto_save_no_changes=True)
+        self.project_manager.startTimerNoChanges()
+        with patch("manuskript.loadSave.saveProject", return_value=True):
+            self.project_manager.saveDatas()
+        self.mock_save_timer_no_changes.stop.assert_called()
+
+    @patch("manuskript.loadSave.saveProject", return_value=True)
+    def test_save_timer_triggers_save_datas(self, mock_save_project):
+        self._load_project_helper(auto_save=True, auto_save_no_changes=False)
+        # Manually trigger the timeout signal
+        self.project_manager.saveTimer.timeout.connect.call_args[0][0]()
+        mock_save_project.assert_called_once()
+
+    @patch("manuskript.loadSave.saveProject", return_value=True)
+    def test_save_timer_no_changes_triggers_save_datas(self, mock_save_project):
+        self._load_project_helper(auto_save=True, auto_save_no_changes=True)
+        self.project_manager.startTimerNoChanges()
+        # Manually trigger the timeout signal
+        self.project_manager.saveTimerNoChanges.timeout.connect.call_args[0][0]()
+        mock_save_project.assert_called_once()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/manuskript/ui/welcome.py
+++ b/manuskript/ui/welcome.py
@@ -82,10 +82,10 @@ class welcome(QWidget, Ui_welcome):
             project = self.mw._autoLoadProject
             self.mw._autoLoadProject = None
             self.appendToRecentFiles(project)
-            self.mw.loadProject(project)
+            self.mw.projectManager.loadProject(project)
 
         elif autoLoad and last:
-            self.mw.loadProject(last)
+            self.mw.projectManager.loadProject(last)
 
     def getAutoLoadValues(self):
         """
@@ -144,8 +144,8 @@ class welcome(QWidget, Ui_welcome):
     def loadRecentFile(self):
         act = self.sender()
         self.appendToRecentFiles(act.data())
-        self.mw.closeProject()
-        self.mw.loadProject(act.data())
+        self.mw.projectManager.closeProject()
+        self.mw.projectManager.loadProject(act.data())
 
     ###############################################################################
     # DIALOGS
@@ -162,7 +162,7 @@ class welcome(QWidget, Ui_welcome):
         if filename:
             self.setLastAccessedDirectory(os.path.dirname(filename))
             self.appendToRecentFiles(filename)
-            self.mw.loadProject(filename)
+            self.mw.projectManager.loadProject(filename)
 
     def saveAsFile(self):
         lastDirectory = self.getLastAccessedDirectory()
@@ -180,7 +180,7 @@ class welcome(QWidget, Ui_welcome):
                 filename += ".msk"
             self.appendToRecentFiles(filename)
             loadSave.clearSaveCache()  # Ensure all file(s) are saved under new filename
-            self.mw.saveDatas(filename)
+            self.mw.projectManager.saveDatas(filename)
             # Update Window's project name with new filename
             pName = os.path.split(filename)[1]
             if pName.endswith('.msk'):
@@ -213,7 +213,7 @@ class welcome(QWidget, Ui_welcome):
             # Create new project
             self.appendToRecentFiles(filename)
             self.loadDefaultDatas()
-            self.mw.loadProject(filename, loadFromFile=False)
+            self.mw.projectManager.loadProject(filename, loadFromFile=False)
 
     ###############################################################################
     # TEMPLATES
@@ -268,7 +268,7 @@ class welcome(QWidget, Ui_welcome):
             # Change button text
             self.btnCreate.setText("Open {}".format(name))
             # Load project
-            self.mw.loadProject(appPath(os.path.join("sample-projects", name)))
+            self.mw.projectManager.loadProject(appPath(os.path.join("sample-projects", name)))
 
     def updateTemplate(self):
         # Clear layout
@@ -440,7 +440,7 @@ class welcome(QWidget, Ui_welcome):
         # Empty settings
         importlib.reload(settings)
         settings.initDefaultValues()
-        self.mw.loadEmptyDatas()
+        self.mw.projectManager.loadEmptyDatas()
 
         if self.template:
             t = [i for i in self._templates if i[0] == self.template[0]]


### PR DESCRIPTION
Major architectural refactoring to improve code organization:

- **Extracted ProjectManager class** from mainWindow.py (~300 lines)
  - Moved project lifecycle methods: loadProject, closeProject, saveDatas
  - Moved timer management: saveTimer, saveTimerNoChanges
  - Moved data management: loadEmptyDatas, loadDatas
  - Moved unsaved changes handling: handleUnsavedChanges
  - Updated all calling code to use projectManager interface

<br>

- `manuskript/projectManager.py` - Project lifecycle management
- `manuskript/tests/test_projectManager.py` - Basic ProjectManager tests (2 tests)
- `manuskript/tests/test_projectManager_timer.py` - Comprehensive timer tests (9 tests)

<br>

- `manuskript/mainWindow.py` - Removed ~300 lines, added projectManager integration
- `manuskript/ui/welcome.py` - Updated to use projectManager interface
- `manuskript/settingsWindow.py` - Updated timer access via projectManager
- `manuskript/tests/conftest.py` - Updated test fixtures for new interface

<br>

- Added 11 new unit tests total covering ProjectManager functionality
- Comprehensive timer testing with proper Qt mocking
- All existing tests continue to pass (50 total tests)
- Tests validate both positive and negative scenarios

<br>

- Reduced mainWindow.py complexity (2000+ -> 1700 lines)
- Improved separation of concerns
- Better testability with isolated components
- Foundation for further architectural improvements