### PR TITLE
fix: loading of large revision files

### DIFF
--- a/manuskript/load_save/version_1.py
+++ b/manuskript/load_save/version_1.py
@@ -30,6 +30,7 @@ from manuskript.ui.listDialog import ListDialog
 
 import logging
 LOGGER = logging.getLogger(__name__)
+_parser = ET.XMLParser(huge_tree=True)
 
 try:
     import zlib  # Used with zipfile for compression
@@ -920,7 +921,7 @@ def loadProject(project, zip=None):
 
     # Adds revisions
     if "revisions.xml" in files:
-        root = ET.fromstring(files["revisions.xml"])
+        root = ET.fromstring(files["revisions.xml"], parser=_parser)
         appendRevisions(mdl, root)
 
     # Check IDS

--- a/manuskript/models/abstractItem.py
+++ b/manuskript/models/abstractItem.py
@@ -33,6 +33,7 @@ class abstractItem():
         self.childItems = []
         self._parent = None
         self._model = model
+        self._parser = ET.XMLParser(huge_tree=True)
 
         self.IDs = ["0"]  # used by root item to store unique IDs
         self._lastPath = ""  # used by loadSave version_1 to remember which files the items comes from,
@@ -305,7 +306,7 @@ class abstractItem():
         item = self.toXMLProcessItem(item)
 
         for i in self.childItems:
-            item.append(ET.XML(i.toXML()))
+            item.append(ET.XML(i.toXML(), parser = self._parser))
 
         return ET.tostring(item)
 


### PR DESCRIPTION
## Description

Large revision xml files can be loaded with this fix. There's a limitation in the xml parser, basically meant to protect web sites from attacks, to reject large files. 

I know the whole revision system should be reworked, as mentionned in #871, so feel free to accept or reject this pull request.

## Tests
I tested this with the help of a python script I wrote that can generate random novels. 

How I tested : 
2. Load a large novel with a revision.xml file of roughly 200 mb of data, saved as separate files
3. Make changes to the novel by adding/removing text
4. Wait that the revision system kicks in 
5. Save that large novel
6. Reload the large novel
7. Perform the same tests on the same novel, but saved as single file.

I also manipulated a novel with a much larger revision file (1.7 Gb)
