### PR TITLE
Add external file change detection with per-file reload banner

### DIFF
--- a/manuskript/load_save/version_1.py
+++ b/manuskript/load_save/version_1.py
@@ -708,7 +708,7 @@ def loadProject(project, zip=None):
         global cache
         cache = files
 
-        # FIXME: watch directory for changes
+        # File watching is handled by MainWindow._startFileWatcher()
 
     # Sort files by keys
     files = OrderedDict(sorted(files.items()))

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -77,7 +77,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.history = History()
         self._previousSelectionEmpty = True
         self._fileWatcher = None
-        self._fileWatcherBlocked = False
         self._changedPaths = set()
 
         self.readSettings()
@@ -1114,15 +1113,13 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def _onExternalFileChanged(self, path):
         """Slot for QFileSystemWatcher. Debounces via timer."""
-        if self._fileWatcherBlocked:
-            return
         self._changedPaths.add(path)
         self._fileWatcherTimer.start()
         LOGGER.debug("External change detected: %s", path)
 
     def _onFileWatcherTimeout(self):
         """Debounce expired. Notify open editors about changed files."""
-        if self._fileWatcherBlocked or not self.currentProject:
+        if not self.currentProject:
             return
 
         paths = self._changedPaths

--- a/manuskript/mainWindow.py
+++ b/manuskript/mainWindow.py
@@ -6,7 +6,7 @@ import re
 
 from PyQt5.Qt import qVersion, PYQT_VERSION_STR
 from PyQt5.QtCore import (pyqtSignal, QSignalMapper, QTimer, QSettings, Qt, QPoint,
-                          QRegExp, QUrl, QSize, QModelIndex)
+                          QRegExp, QUrl, QSize, QModelIndex, QFileSystemWatcher)
 from PyQt5.QtGui import QStandardItemModel, QIcon, QColor, QStandardItem
 from PyQt5.QtWidgets import QMainWindow, QHeaderView, qApp, QMenu, QActionGroup, QAction, QStyle, QListWidgetItem, \
     QLabel, QDockWidget, QWidget, QMessageBox, QLineEdit, QTextEdit, QTreeView, QDialog, QTableView
@@ -76,6 +76,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.sessionStartWordCount = 0  # Used to track session targets
         self.history = History()
         self._previousSelectionEmpty = True
+        self._fileWatcher = None
+        self._fileWatcherBlocked = False
+        self._changedPaths = set()
 
         self.readSettings()
 
@@ -1009,6 +1012,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # Reset history
         self.history.reset()
 
+        # Watch project files for external changes
+        self._startFileWatcher(project)
+
         # Show main Window
         self.switchToProject()
 
@@ -1046,6 +1052,109 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         return True  # the situation has been handled
 
 
+    ###############################################################################
+    # FILE WATCHER — detect external changes and propose reload
+    ###############################################################################
+
+    def _collectWatchPaths(self, projectDir):
+        """Collect content files and directories to watch, skipping hidden entries."""
+        watchFiles = []
+        watchDirs = [projectDir]
+        for dirpath, dirnames, filenames in os.walk(projectDir):
+            if os.path.basename(dirpath).startswith("."):
+                continue
+            for d in dirnames:
+                if not d.startswith("."):
+                    watchDirs.append(os.path.join(dirpath, d))
+            for f in filenames:
+                if not f.startswith("."):
+                    watchFiles.append(os.path.join(dirpath, f))
+        return watchFiles, watchDirs
+
+    def _startFileWatcher(self, project):
+        """Set up a QFileSystemWatcher on the project's data directory."""
+        self._stopFileWatcher()
+
+        projectDir = os.path.splitext(project)[0]
+        if not os.path.isdir(projectDir):
+            return
+
+        self._fileWatcher = QFileSystemWatcher(self)
+        self._watchedProjectDir = projectDir
+
+        watchFiles, watchDirs = self._collectWatchPaths(projectDir)
+        if watchDirs:
+            self._fileWatcher.addPaths(watchDirs)
+        if watchFiles:
+            self._fileWatcher.addPaths(watchFiles)
+
+        self._fileWatcherTimer = QTimer(self)
+        self._fileWatcherTimer.setSingleShot(True)
+        self._fileWatcherTimer.setInterval(1500)
+        self._fileWatcherTimer.timeout.connect(self._onFileWatcherTimeout)
+
+        self._fileWatcher.fileChanged.connect(self._onExternalFileChanged)
+        self._fileWatcher.directoryChanged.connect(self._onExternalFileChanged)
+
+        LOGGER.info("File watcher started on %s (%d files, %d dirs)",
+                    projectDir, len(watchFiles), len(watchDirs))
+
+    def _stopFileWatcher(self):
+        """Remove the file watcher."""
+        if self._fileWatcher is not None:
+            self._fileWatcher.fileChanged.disconnect(self._onExternalFileChanged)
+            self._fileWatcher.directoryChanged.disconnect(self._onExternalFileChanged)
+            self._fileWatcher.removePaths(self._fileWatcher.files() + self._fileWatcher.directories())
+            self._fileWatcher.deleteLater()
+            self._fileWatcher = None
+        if hasattr(self, '_fileWatcherTimer') and self._fileWatcherTimer is not None:
+            self._fileWatcherTimer.stop()
+            self._fileWatcherTimer.deleteLater()
+            self._fileWatcherTimer = None
+
+    def _onExternalFileChanged(self, path):
+        """Slot for QFileSystemWatcher. Debounces via timer."""
+        if self._fileWatcherBlocked:
+            return
+        self._changedPaths.add(path)
+        self._fileWatcherTimer.start()
+        LOGGER.debug("External change detected: %s", path)
+
+    def _onFileWatcherTimeout(self):
+        """Debounce expired. Notify open editors about changed files."""
+        if self._fileWatcherBlocked or not self.currentProject:
+            return
+
+        paths = self._changedPaths
+        self._changedPaths = set()
+
+        # Notify all open editorWidgets
+        for ts in self.mainEditor.allTabSplitters():
+            for i in range(ts.tab.count()):
+                editor = ts.tab.widget(i)
+                if editor and hasattr(editor, 'notifyExternalChange'):
+                    for p in paths:
+                        editor.notifyExternalChange(p)
+
+        # Re-sync watcher (files may have been added/removed)
+        self._refreshWatcherPaths()
+
+    def _refreshWatcherPaths(self):
+        """Re-add paths that inotify may have dropped after a file change."""
+        if not self._fileWatcher or not hasattr(self, '_watchedProjectDir'):
+            return
+        currentFiles = set(self._fileWatcher.files())
+        currentDirs = set(self._fileWatcher.directories())
+        wantFiles, wantDirs = self._collectWatchPaths(self._watchedProjectDir)
+
+        missingFiles = [f for f in wantFiles if f not in currentFiles]
+        missingDirs = [d for d in wantDirs if d not in currentDirs]
+
+        if missingFiles:
+            self._fileWatcher.addPaths(missingFiles)
+        if missingDirs:
+            self._fileWatcher.addPaths(missingDirs)
+
     def closeProject(self):
 
         if not self.currentProject:
@@ -1063,6 +1172,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.currentProject = None
         self.projectDirty = None
         QSettings().setValue("lastProject", "")
+
+        # Stop file watcher
+        self._stopFileWatcher()
 
         # Clear datas
         self.loadEmptyDatas()

--- a/manuskript/ui/editors/editorWidget.py
+++ b/manuskript/ui/editors/editorWidget.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python
 # --!-- coding: utf8 --!--
+import logging
+import os
+
 from PyQt5.QtCore import pyqtSignal, QModelIndex
 from PyQt5.QtGui import QPalette
 from PyQt5.QtWidgets import QWidget, QFrame, QSpacerItem, QSizePolicy
-from PyQt5.QtWidgets import QVBoxLayout, qApp, QStyle
+from PyQt5.QtWidgets import QVBoxLayout, QGraphicsOpacityEffect, qApp, QStyle
 
 from manuskript import settings
 from manuskript.functions import AUC, mainWindow
+from manuskript.load_save.version_1 import outlineItemPath
 from manuskript.ui.editors.editorWidget_ui import Ui_editorWidget_ui
 from manuskript.ui.views.MDEditView import MDEditView
 from manuskript.ui.tools.splitDialog import splitDialog
+
+LOGGER = logging.getLogger(__name__)
 
 
 class editorWidget(QWidget, Ui_editorWidget_ui):
@@ -58,6 +64,11 @@ class editorWidget(QWidget, Ui_editorWidget_ui):
         self.folderView = "cork"
         self.mw = mainWindow()
         self._tabWidget = None  # set by mainEditor on creation
+
+        # External file change tracking
+        self._changedFiles = set()
+        self.reloadBannerBtn.clicked.connect(self._onReloadBannerClicked)
+        self.reloadBannerDismiss.clicked.connect(self._onDismissBanner)
 
         self._model = None
 
@@ -311,6 +322,13 @@ class editorWidget(QWidget, Ui_editorWidget_ui):
         if self._model:
             self.setView()
 
+        # Lock/unlock based on whether this file was externally modified
+        fp = self.getItemFilePath()
+        if fp and os.path.normpath(fp) in self._changedFiles:
+            self._lockEditor()
+        else:
+            self._unlockEditor()
+
     def updateIndexFromID(self, fallback=None, ignore=None):
         """
         Index might have changed (through drag an drop), so we keep current
@@ -387,6 +405,75 @@ class editorWidget(QWidget, Ui_editorWidget_ui):
             return
 
         mw.mainEditor.tabChanged()
+
+    def getItemFilePath(self):
+        """Returns the on-disk path for the current outline item, or None."""
+        if not self.currentIndex.isValid():
+            return None
+        item = self.currentIndex.internalPointer()
+        if not item or item.type() == "folder":
+            return None
+        mw = mainWindow()
+        if not mw or not mw.currentProject:
+            return None
+        folder = os.path.splitext(mw.currentProject)[0]
+        return os.path.join(folder, *outlineItemPath(item))
+
+    def notifyExternalChange(self, path):
+        """Show reload banner if `path` matches the currently displayed file."""
+        self._changedFiles.add(os.path.normpath(path))
+        fp = self.getItemFilePath()
+        if fp and os.path.normpath(fp) in self._changedFiles:
+            self._lockEditor()
+
+    def _lockEditor(self):
+        """Show banner, dim text with opacity, block editing."""
+        if self.txtRedacText.isReadOnly():
+            return  # already locked
+        self.reloadBanner.show()
+        self.txtRedacText.setReadOnly(True)
+        effect = QGraphicsOpacityEffect(self.txtRedacText)
+        effect.setOpacity(0.35)
+        self.txtRedacText.setGraphicsEffect(effect)
+
+    def _unlockEditor(self):
+        """Hide banner, restore editing."""
+        self.reloadBanner.hide()
+        if not self.txtRedacText.isReadOnly():
+            return  # already unlocked
+        self.txtRedacText.setReadOnly(False)
+        self.txtRedacText.setGraphicsEffect(None)
+
+    def _onReloadBannerClicked(self):
+        """Reload this single file's content from disk."""
+        fp = self.getItemFilePath()
+        if fp and os.path.exists(fp):
+            with open(fp, 'rt', encoding='utf-8') as f:
+                content = f.read()
+            body = self._parseMMDBody(content)
+            self.txtRedacText.setPlainText(body)
+            LOGGER.info("Reloaded file: %s", fp)
+        self._clearChangedFile()
+
+    def _onDismissBanner(self):
+        self._clearChangedFile()
+
+    def _clearChangedFile(self):
+        fp = self.getItemFilePath()
+        if fp:
+            self._changedFiles.discard(os.path.normpath(fp))
+        self._unlockEditor()
+
+    @staticmethod
+    def _parseMMDBody(content):
+        """Strip optional MMD metadata header (key: value lines at the top)."""
+        lines = content.split('\n')
+        i = 0
+        while i < len(lines) and ':' in lines[i] and lines[i].strip():
+            i += 1
+        if i > 0 and i < len(lines) and lines[i].strip() == '':
+            i += 1  # skip blank line after metadata
+        return '\n'.join(lines[i:])
 
     def toggleSpellcheck(self, v):
         self.spellcheck = v

--- a/manuskript/ui/editors/editorWidget.py
+++ b/manuskript/ui/editors/editorWidget.py
@@ -420,11 +420,25 @@ class editorWidget(QWidget, Ui_editorWidget_ui):
         return os.path.join(folder, *outlineItemPath(item))
 
     def notifyExternalChange(self, path):
-        """Show reload banner if `path` matches the currently displayed file."""
-        self._changedFiles.add(os.path.normpath(path))
+        """Show reload banner only if file on disk truly differs from editor."""
         fp = self.getItemFilePath()
-        if fp and os.path.normpath(fp) in self._changedFiles:
-            self._lockEditor()
+        if not fp:
+            return
+        normPath = os.path.normpath(path)
+        normFp = os.path.normpath(fp)
+        if normPath != normFp:
+            return
+        # Compare disk content with current editor text
+        try:
+            with open(fp, 'rt', encoding='utf-8') as f:
+                diskBody = self._parseMMDBody(f.read())
+        except (OSError, UnicodeDecodeError):
+            return
+        if diskBody == self.txtRedacText.toPlainText():
+            self._changedFiles.discard(normFp)
+            return
+        self._changedFiles.add(normFp)
+        self._lockEditor()
 
     def _lockEditor(self):
         """Show banner, dim text with opacity, block editing."""
@@ -471,8 +485,9 @@ class editorWidget(QWidget, Ui_editorWidget_ui):
         i = 0
         while i < len(lines) and ':' in lines[i] and lines[i].strip():
             i += 1
-        if i > 0 and i < len(lines) and lines[i].strip() == '':
-            i += 1  # skip blank line after metadata
+        # skip all blank lines between metadata and body
+        while i < len(lines) and lines[i].strip() == '':
+            i += 1
         return '\n'.join(lines[i:])
 
     def toggleSpellcheck(self, v):

--- a/manuskript/ui/editors/editorWidget_ui.py
+++ b/manuskript/ui/editors/editorWidget_ui.py
@@ -19,13 +19,44 @@ class Ui_editorWidget_ui(object):
         self.stack.setObjectName("stack")
         self.text = QtWidgets.QWidget()
         self.text.setObjectName("text")
-        self.horizontalLayout_2 = QtWidgets.QHBoxLayout(self.text)
-        self.horizontalLayout_2.setContentsMargins(0, 0, 0, 0)
-        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
+        self.textLayout = QtWidgets.QVBoxLayout(self.text)
+        self.textLayout.setContentsMargins(0, 0, 0, 0)
+        self.textLayout.setSpacing(0)
+        self.textLayout.setObjectName("textLayout")
+        # Reload banner (hidden by default)
+        self.reloadBanner = QtWidgets.QFrame(self.text)
+        self.reloadBanner.setObjectName("reloadBanner")
+        self.reloadBanner.setStyleSheet(
+            "QFrame#reloadBanner {"
+            "  background: #e65100; border-bottom: 2px solid #bf360c;"
+            "  color: white; font-weight: bold; font-size: 13px;"
+            "}"
+            "QFrame#reloadBanner QPushButton {"
+            "  background: white; color: black; border: none;"
+            "  border-radius: 3px; padding: 4px 12px;"
+            "}"
+            "QFrame#reloadBanner QPushButton:hover { background: #fff3e0; }"
+        )
+        self.reloadBanner.setFixedHeight(44)
+        self.reloadBanner.hide()
+        self.reloadBannerLayout = QtWidgets.QHBoxLayout(self.reloadBanner)
+        self.reloadBannerLayout.setContentsMargins(16, 6, 16, 6)
+        self.reloadBannerLabel = QtWidgets.QLabel(self.reloadBanner)
+        self.reloadBannerLabel.setText("")
+        self.reloadBannerLayout.addWidget(self.reloadBannerLabel)
+        self.reloadBannerLayout.addStretch()
+        self.reloadBannerBtn = QtWidgets.QPushButton("", self.reloadBanner)
+        self.reloadBannerBtn.setFixedWidth(110)
+        self.reloadBannerLayout.addWidget(self.reloadBannerBtn)
+        self.reloadBannerDismiss = QtWidgets.QPushButton("", self.reloadBanner)
+        self.reloadBannerDismiss.setFixedWidth(80)
+        self.reloadBannerLayout.addWidget(self.reloadBannerDismiss)
+        self.textLayout.addWidget(self.reloadBanner)
+        # Editor
         self.txtRedacText = MDEditView(self.text)
         self.txtRedacText.setFrameShape(QtWidgets.QFrame.NoFrame)
         self.txtRedacText.setObjectName("txtRedacText")
-        self.horizontalLayout_2.addWidget(self.txtRedacText)
+        self.textLayout.addWidget(self.txtRedacText)
         self.stack.addWidget(self.text)
         self.folder = QtWidgets.QWidget()
         self.folder.setObjectName("folder")
@@ -73,6 +104,9 @@ class Ui_editorWidget_ui(object):
     def retranslateUi(self, editorWidget_ui):
         _translate = QtCore.QCoreApplication.translate
         editorWidget_ui.setWindowTitle(_translate("editorWidget_ui", "Form"))
+        self.reloadBannerLabel.setText(_translate("editorWidget_ui", "This file has been modified outside Manuskript."))
+        self.reloadBannerBtn.setText(_translate("editorWidget_ui", "Reload"))
+        self.reloadBannerDismiss.setText(_translate("editorWidget_ui", "Dismiss"))
 
 from manuskript.ui.views.MDEditView import MDEditView
 from manuskript.ui.views.corkView import corkView


### PR DESCRIPTION
## Motivation

Manuskript stores its project as a folder of plain text files (`.md`, `.txt`, `.xml`, `.opml`), which makes it naturally compatible with Git and other version control systems. Many writers use Git to track revisions, collaborate, or sync between machines.

However, when files change on disk — after a `git pull`, a `git checkout`, a rebase, or even an edit from an external text editor — Manuskript has no way of knowing. The user must close and reopen the project to see the updated content, which is error-prone and can lead to data loss if Manuskript's autosave overwrites the newer version on disk.

This PR implements the long-standing `FIXME: watch directory for changes` (load_save/version_1.py, line 711) to solve this problem.

## What it does

When project files are modified outside Manuskript, the editor now:

1. **Detects the change** via `QFileSystemWatcher` (inotify on Linux, FSEvents on macOS, ReadDirectoryChanges on Windows)
2. **Shows a banner** above the affected file's editor with "Reload" and "Dismiss" buttons
3. **Locks the editor** (read-only + opacity dim) until the user responds — preventing accidental overwrites
4. **Persists state across navigation** — switching away and back to a modified file still shows the banner

This is a per-file notification, not a project-wide reload dialog. Only the files that actually changed on disk are flagged.

## Typical use cases

- `git pull` or `git merge` updates several chapter files → each affected editor tab shows the banner
- External text editor (Vim, VS Code, etc.) modifies a scene → Manuskript detects it immediately
- Sync tools (Syncthing, Dropbox) update files in the background → user is notified before editing stale content

## Changes

**`mainWindow.py`** — Project-level file watcher
- `QFileSystemWatcher` monitors all files and directories in the project folder
- 1.5s debounce timer coalesces rapid changes into a single notification
- After each notification, re-syncs inotify watches (Linux drops them after file modification)
- Watcher starts on `loadProject()`, stops on `closeProject()`

**`ui/editors/editorWidget.py`** — Per-file change tracking and reload
- `notifyExternalChange(path)`: records changed files, locks editor if current file is affected
- `_lockEditor()` / `_unlockEditor()`: banner + read-only + `QGraphicsOpacityEffect(0.35)`
- `_onReloadBannerClicked()`: re-reads the file from disk, strips MMD metadata header, updates editor content
- `_onDismissBanner()`: clears changed state, unlocks editor
- `setCurrentModelIndex()`: re-applies lock/unlock state when navigating between files

**`ui/editors/editorWidget_ui.py`** — Banner UI
- Orange banner (44px) with translatable label and two buttons
- All strings go through `retranslateUi` / `QCoreApplication.translate` for i18n support

**`load_save/version_1.py`**
- Replaced `# FIXME: watch directory for changes` with implementation reference

## Performance

- Uses kernel-level file watching (inotify/FSEvents/ReadDirectoryChanges), zero CPU cost at idle
- ~200 watches for a typical project (well within Linux default limit of 65k+)
- Debounce prevents notification storms during batch edits (e.g. `git checkout` touching many files)
- `_refreshWatcherPaths` only adds missing watches, no full remove + re-add cycle
- Guard checks in `_lockEditor` / `_unlockEditor` prevent redundant effect creation

## Test plan

- [ ] Open a project, modify a `.md` file externally → banner appears, text is dimmed, editor is read-only
- [ ] Click "Reload" → file content updates from disk, banner disappears, editor is editable
- [ ] Click "Dismiss" → banner disappears, editor is editable (keeps in-memory content)
- [ ] Navigate away from modified file and back → banner reappears
- [ ] Navigate to a non-modified file → no banner, editor works normally
- [ ] Close project → no errors, watcher is cleaned up
- [ ] Run `git pull` that modifies several files → each affected tab shows banner independently
- [ ] Test with dark and light themes → opacity dim works correctly with both