### PR TITLE
ci(packaging): fallback to PyQtWebEngine for Debian 13 compatibility

### DIFF
--- a/package/create_deb/control
+++ b/package/create_deb/control
@@ -2,18 +2,16 @@ Package: manuskript
 Version: {PkgVersion}
 Maintainer: Tobias Frisch <thejackimonster@gmail.com>
 Description: Manuskript open source tool for writers.
- Manuskript is an open source tool for writers.  It
+ Manuskript is an open source tool for writers. It
  provides a rich environment to help writers create
  their first draft and then further refine and edit
  their masterpiece.
-Section: office, text
+Section: editors
 Priority: optional
 Installed-Size: {PkgSizeInKb}
 Architecture: all
-Origin: Ubuntu 14.04
 Bugs: https://github.com/olivierkes/manuskript/issues
 Homepage: http://www.theologeek.ch/manuskript/
-Source: https://github.com/olivierkes/manuskript/archive/0.14.0.tar.gz
-Depends: python3, python3-pyqt5, python3-pyqt5.qtwebkit, libqt5svg5,
- python3-lxml, zlib1g, python3-enchant, python3-markdown, pandoc
+Source: https://github.com/olivierkes/manuskript/archive/refs/tags/{PkgVersion}.tar.gz
+Depends: python3, python3-pyqt5, python3-pyqt5.qtwebengine | python3-pyqt5.qtwebkit, libqt5svg5, python3-lxml, zlib1g, python3-enchant, python3-markdown, pandoc
 Suggests: texlive-latex-recommended


### PR DESCRIPTION
Debian 13 (Trixie) removed python3-pyqt5.qtwebkit due to QtWebKit deprecation. Update debian/control dependency metadata to allow python3-pyqt5.qtwebengine as the primary backend dependency while retaining python3-pyqt5.qtwebkit as a fallback.

Additional metadata updates:
- Parameterize Source archive URL using {PkgVersion}
- Fix invalid multi-value Section header to 'editors' per Debian Policy 2.4
- Remove obsolete Origin field

Closes: #1438